### PR TITLE
Add Flask TicketTracker application with UI and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,42 @@ Requirements and Expected Behavior
 	•	Flexible enough to act as personal help desk, client tracker, or to-do manager.
 
 In short: TicketTracker should function as a small, private help-desk system that visually prioritizes tasks by time and importance, maintains full history and attachments, and stays entirely under the user’s control.
+---
+
+## Getting started
+
+### Prerequisites
+- Python 3.10 or newer
+- `pip` for installing Python packages
+
+### Installation
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+### Configuration
+Runtime behaviour is driven by `config.json` in the project root. The file controls:
+- database location (`database.uri`, defaults to SQLite beside the project)
+- uploads directory (`uploads.directory`)
+- workflow statuses, priorities, and hold reasons
+- SLA timing thresholds used for ticket colouring
+- palette overrides for statuses, priorities, and tag chips
+
+You can provide a different configuration by setting `TICKETTRACKER_CONFIG` to an alternate JSON file path before starting the app.
+
+### Running the development server
+```bash
+flask --app tickettracker.app:create_app run --debug
+```
+
+The command creates the SQLite database (if missing), ensures the uploads directory exists, and serves the UI at <http://127.0.0.1:5000>.
+
+Uploaded attachments are stored locally under the directory defined in the JSON configuration (defaults to `uploads/`). Backing up the database file and uploads folder is sufficient to preserve all data.
+
+### Workflow highlights
+- Tickets can be created, edited, filtered, and searched from the dashboard.
+- Status transitions automatically create audit-log entries on the ticket timeline.
+- Attachments may be added when creating tickets or posting updates, and can be downloaded from the detail page.
+- SLA-based colouring, tag chips, and hold-reason presets all respond to configuration changes without code edits.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,49 @@
+{
+  "database": {
+    "uri": "sqlite:///tickettracker.db"
+  },
+  "uploads": {
+    "directory": "uploads"
+  },
+  "priorities": ["Low", "Medium", "High", "Urgent"],
+  "hold_reasons": [
+    "Awaiting customer response",
+    "Blocked by dependency",
+    "Pending scheduled work",
+    "Researching solution"
+  ],
+  "workflow": ["Open", "In Progress", "On Hold", "Resolved", "Closed", "Cancelled"],
+  "sla": {
+    "due_soon_hours": 24,
+    "overdue_grace_minutes": 30,
+    "priority_open_days": {
+      "Low": 7,
+      "Medium": 5,
+      "High": 3,
+      "Urgent": 1
+    }
+  },
+  "colors": {
+    "gradient": {
+      "safe": "#38bdf8",
+      "warning": "#facc15",
+      "overdue": "#f87171"
+    },
+    "statuses": {
+      "on_hold": "#9c88ff",
+      "resolved": "#34d399",
+      "closed": "#475569",
+      "cancelled": "#64748b"
+    },
+    "priorities": {
+      "Low": "#34d399",
+      "Medium": "#facc15",
+      "High": "#fb7185",
+      "Urgent": "#f43f5e"
+    },
+    "tags": {
+      "background": "#1e293b",
+      "text": "#e2e8f0"
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=2.3
+Flask-SQLAlchemy>=3.0
+SQLAlchemy>=2.0

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,505 @@
+:root {
+  color-scheme: dark;
+  --background: #0f172a;
+  --surface: #111827;
+  --surface-muted: #1f2937;
+  --border: #1f2937;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --accent: #38bdf8;
+  --accent-muted: rgba(56, 189, 248, 0.2);
+  --danger: #f87171;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.05), transparent 60%),
+    radial-gradient(circle at bottom right, rgba(139, 92, 246, 0.08), transparent 55%),
+    var(--background);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+h1,
+ h2,
+ h3,
+ h4,
+ h5,
+ h6 {
+  font-weight: 600;
+  color: #f8fafc;
+  margin: 0;
+}
+
+p {
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 5vw;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand .logo {
+  font-size: 2rem;
+}
+
+.brand .subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.nav-links a {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.nav-links .button.primary {
+  padding: 0.5rem 1.25rem;
+}
+
+.content {
+  width: min(1100px, 92vw);
+  margin: 2rem auto 4rem;
+  flex: 1;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.75rem;
+  padding: 0.6rem 1.2rem;
+  color: var(--text);
+  cursor: pointer;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.button:hover {
+  border-color: rgba(56, 189, 248, 0.7);
+  text-decoration: none;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.25), rgba(129, 140, 248, 0.35));
+  border-color: rgba(56, 189, 248, 0.6);
+}
+
+.panel {
+  background: rgba(17, 24, 39, 0.85);
+  padding: 1.75rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  margin-bottom: 2rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+}
+
+.filter-form,
+.ticket-form,
+.update-form {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field-group label {
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.field-group input,
+.field-group textarea,
+.field-group select {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  color: var(--text);
+  font: inherit;
+  resize: vertical;
+}
+
+.field-group input:focus,
+.field-group textarea:focus,
+.field-group select:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.4);
+  border-color: rgba(56, 189, 248, 0.6);
+}
+
+.field-group.split {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.field-group[data-hidden] {
+  display: none;
+}
+
+.tag-mode {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.ticket-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.ticket-card {
+  background: linear-gradient(145deg, rgba(17, 24, 39, 0.95), rgba(15, 23, 42, 0.85));
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.08);
+  position: relative;
+  overflow: hidden;
+}
+
+.ticket-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 2px solid var(--ticket-accent, var(--accent));
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.ticket-card header,
+.ticket-detail > header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.ticket-card .title-group h2 {
+  margin-bottom: 0.35rem;
+}
+
+.ticket-card .meta,
+.ticket-detail .meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.priority[data-priority='Urgent'] {
+  color: #fda4af;
+}
+
+.priority[data-priority='High'] {
+  color: #fca5a5;
+}
+
+.priority[data-priority='Medium'] {
+  color: #facc15;
+}
+
+.priority[data-priority='Low'] {
+  color: #34d399;
+}
+
+.ticket-card .timestamps,
+.ticket-detail .timestamps {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-align: right;
+}
+
+.ticket-card .description {
+  margin-top: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.ticket-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.ticket-details div {
+  background: rgba(15, 23, 42, 0.6);
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.ticket-details dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.ticket-details dd {
+  margin: 0;
+  color: var(--text);
+}
+
+.tags {
+  list-style: none;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+}
+
+.tags li {
+  background: var(--tag-color, rgba(30, 41, 59, 0.8));
+  color: var(--tag-text, var(--text));
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.03em;
+}
+
+.ticket-card footer {
+  margin-top: 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.ticket-detail {
+  background: linear-gradient(145deg, rgba(17, 24, 39, 0.95), rgba(30, 41, 59, 0.75));
+  padding: 2rem;
+  border-radius: 1.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  margin-bottom: 2rem;
+  position: relative;
+}
+
+.ticket-detail::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 3px solid var(--ticket-accent, rgba(56, 189, 248, 0.6));
+  opacity: 0.2;
+  pointer-events: none;
+}
+
+.detail-grid {
+  margin-top: 1.75rem;
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
+}
+
+.detail-grid aside dl {
+  display: grid;
+  gap: 1rem;
+}
+
+.detail-grid aside dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.detail-grid aside dd {
+  margin: 0;
+}
+
+.actions .button {
+  width: fit-content;
+}
+
+.attachments ul,
+.update-attachments {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.attachment-meta {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  margin-left: 0.5rem;
+}
+
+.timeline {
+  list-style: none;
+  margin: 2rem 0 0;
+  padding: 0;
+  position: relative;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 10px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.timeline li {
+  position: relative;
+  padding-left: 2.5rem;
+  margin-bottom: 1.75rem;
+}
+
+.timeline li:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-point {
+  position: absolute;
+  left: 4px;
+  top: 6px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--ticket-accent, var(--accent));
+}
+
+.timeline-content {
+  background: rgba(15, 23, 42, 0.75);
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.update-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.empty-state,
+.timeline li.empty,
+.attachments .empty {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 2rem;
+  border: 1px dashed rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+}
+
+.flash-container {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.flash {
+  padding: 0.85rem 1.2rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(30, 41, 59, 0.7);
+}
+
+.flash.success {
+  border-color: rgba(134, 239, 172, 0.4);
+}
+
+.flash.error {
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
+.app-footer {
+  padding: 2rem 5vw;
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+  background: rgba(15, 23, 42, 0.7);
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 900px) {
+  .app-header {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+
+  .ticket-detail {
+    padding: 1.5rem;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ticket-card header,
+  .ticket-detail > header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .ticket-card .timestamps,
+  .ticket-detail .timestamps {
+    text-align: left;
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}TicketTracker{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="brand">
+        <span class="logo">🎫</span>
+        <div>
+          <h1>TicketTracker</h1>
+          <p class="subtitle">Local-first ticketing desk</p>
+        </div>
+      </div>
+      <nav class="nav-links">
+        <a href="{{ url_for('tickets.list_tickets') }}">Tickets</a>
+        <a href="{{ url_for('tickets.create_ticket') }}" class="button primary">New Ticket</a>
+      </nav>
+    </header>
+
+    <main class="content">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          <div class="flash-container">
+            {% for category, message in messages %}
+              <div class="flash {{ category }}">{{ message }}</div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="app-footer">
+      <p>Uploads stored in <code>{{ app_config.uploads_path }}</code>. Customize colors and SLAs via the JSON config.</p>
+    </footer>
+  </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,118 @@
+{% extends "base.html" %}
+{% block title %}Tickets · TicketTracker{% endblock %}
+{% block content %}
+<section class="panel">
+  <form method="get" class="filter-form">
+    <div class="field-group">
+      <label for="search">Search</label>
+      <input type="search" id="search" name="q" placeholder="Search tickets" value="{{ filters.search or '' }}" />
+    </div>
+    <div class="field-group">
+      <label for="status">Status</label>
+      <select id="status" name="status">
+        <option value="">All</option>
+        {% for status in config.workflow %}
+          <option value="{{ status }}" {% if filters.status == status %}selected{% endif %}>{{ status }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="field-group">
+      <label for="priority">Priority</label>
+      <select id="priority" name="priority">
+        <option value="">All</option>
+        {% for priority in priorities %}
+          <option value="{{ priority }}" {% if filters.priority == priority %}selected{% endif %}>{{ priority }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="field-group">
+      <label for="tag">Tags</label>
+      <select id="tag" name="tag" multiple size="3">
+        {% for tag in available_tags %}
+          <option value="{{ tag.name }}" {% if tag.name in filters.tags %}selected{% endif %}>{{ tag.name }}</option>
+        {% endfor %}
+      </select>
+      <div class="tag-mode">
+        <label><input type="radio" name="tag_mode" value="any" {% if filters.tag_mode != 'all' %}checked{% endif %} /> Any</label>
+        <label><input type="radio" name="tag_mode" value="all" {% if filters.tag_mode == 'all' %}checked{% endif %} /> All</label>
+      </div>
+    </div>
+    <div class="field-group">
+      <label for="sort">Sort</label>
+      <select id="sort" name="sort">
+        <option value="due" {% if filters.sort == 'due' %}selected{% endif %}>Due date</option>
+        <option value="priority" {% if filters.sort == 'priority' %}selected{% endif %}>Priority</option>
+        <option value="updated" {% if filters.sort == 'updated' %}selected{% endif %}>Recently updated</option>
+        <option value="created" {% if filters.sort == 'created' %}selected{% endif %}>Newest</option>
+      </select>
+    </div>
+    <div class="actions">
+      <button type="submit" class="button primary">Apply</button>
+      <a href="{{ url_for('tickets.list_tickets') }}" class="button">Reset</a>
+    </div>
+  </form>
+</section>
+
+<section class="ticket-grid">
+  {% if tickets %}
+    {% for ticket in tickets %}
+      <article class="ticket-card" style="--ticket-accent: {{ ticket.display_color }};">
+        <header>
+          <div class="title-group">
+            <h2><a href="{{ url_for('tickets.ticket_detail', ticket_id=ticket.id) }}">{{ ticket.title }}</a></h2>
+            <div class="meta">
+              <span class="status">{{ ticket.status }}{% if ticket.status == 'On Hold' and ticket.on_hold_reason %} · {{ ticket.on_hold_reason }}{% endif %}</span>
+              <span class="priority" data-priority="{{ ticket.priority }}">{{ ticket.priority }}</span>
+              {% if ticket.due_date %}
+                <span class="due">Due {{ ticket.due_date.strftime('%b %d, %Y %H:%M') }}</span>
+              {% else %}
+                <span class="due no-date">No due date</span>
+              {% endif %}
+            </div>
+          </div>
+          <div class="timestamps">
+            <span title="Created">🕒 {{ ticket.created_at.strftime('%b %d, %Y') }}</span>
+            <span title="Updated">🔄 {{ ticket.updated_at.strftime('%b %d, %Y %H:%M') }}</span>
+          </div>
+        </header>
+        <p class="description">{{ ticket.description|truncate(240) }}</p>
+        <dl class="ticket-details">
+          {% if ticket.requester %}
+            <div>
+              <dt>Requester</dt>
+              <dd>{{ ticket.requester }}</dd>
+            </div>
+          {% endif %}
+          {% if ticket.watchers %}
+            <div>
+              <dt>Watchers</dt>
+              <dd>{{ ticket.watchers|join(', ') }}</dd>
+            </div>
+          {% endif %}
+          {% if ticket.links %}
+            <div>
+              <dt>Links</dt>
+              <dd>{{ ticket.links }}</dd>
+            </div>
+          {% endif %}
+        </dl>
+        {% if ticket.tags %}
+          <ul class="tags">
+            {% for tag in ticket.tags %}
+              <li style="--tag-color: {{ tag.color or config.colors.tags.background }}; --tag-text: {{ config.colors.tags.text }}">{{ tag.name }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+        <footer>
+          <span>{{ ticket.updates|length }} updates</span>
+          <span>{{ ticket.attachments|length }} attachments</span>
+        </footer>
+      </article>
+    {% endfor %}
+  {% else %}
+    <div class="empty-state">
+      <p>No tickets found. <a href="{{ url_for('tickets.create_ticket') }}">Create your first ticket.</a></p>
+    </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -1,0 +1,176 @@
+{% extends "base.html" %}
+{% block title %}{{ ticket.title }} · TicketTracker{% endblock %}
+{% block content %}
+<article class="ticket-detail" style="--ticket-accent: {{ ticket.display_color }};">
+  <header>
+    <div class="title-group">
+      <h2>{{ ticket.title }}</h2>
+      <div class="meta">
+        <span class="status">{{ ticket.status }}{% if ticket.status == 'On Hold' and ticket.on_hold_reason %} · {{ ticket.on_hold_reason }}{% endif %}</span>
+        <span class="priority" data-priority="{{ ticket.priority }}">{{ ticket.priority }}</span>
+        {% if ticket.due_date %}
+          <span class="due">Due {{ ticket.due_date.strftime('%b %d, %Y %H:%M') }}</span>
+        {% else %}
+          <span class="due no-date">No due date</span>
+        {% endif %}
+      </div>
+    </div>
+    <div class="timestamps">
+      <span>Created {{ ticket.created_at.strftime('%b %d, %Y %H:%M') }}</span>
+      <span>Updated {{ ticket.updated_at.strftime('%b %d, %Y %H:%M') }}</span>
+    </div>
+  </header>
+
+  <section class="detail-grid">
+    <div>
+      <h3>Description</h3>
+      <p>{{ ticket.description|urlize|replace('\n', '<br />')|safe }}</p>
+    </div>
+    <aside>
+      <dl>
+        {% if ticket.requester %}
+          <div>
+            <dt>Requester</dt>
+            <dd>{{ ticket.requester }}</dd>
+          </div>
+        {% endif %}
+        {% if ticket.watchers %}
+          <div>
+            <dt>Watchers</dt>
+            <dd>{{ ticket.watchers|join(', ') }}</dd>
+          </div>
+        {% endif %}
+        {% if ticket.links %}
+          <div>
+            <dt>Links</dt>
+            <dd>{{ ticket.links|urlize }}</dd>
+          </div>
+        {% endif %}
+        {% if ticket.notes %}
+          <div>
+            <dt>Notes</dt>
+            <dd>{{ ticket.notes|urlize|replace('\n', '<br />')|safe }}</dd>
+          </div>
+        {% endif %}
+      </dl>
+      <div class="actions">
+        <a class="button" href="{{ url_for('tickets.edit_ticket', ticket_id=ticket.id) }}">Edit ticket</a>
+      </div>
+    </aside>
+  </section>
+
+  {% if ticket.tags %}
+    <section class="tag-list">
+      <h3>Tags</h3>
+      <ul class="tags">
+        {% for tag in ticket.tags %}
+          <li style="--tag-color: {{ tag.color or config.colors.tags.background }}; --tag-text: {{ config.colors.tags.text }}">{{ tag.name }}</li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
+  <section class="attachments">
+    <h3>Attachments</h3>
+    {% if ticket.attachments %}
+      <ul>
+        {% for attachment in ticket.attachments %}
+          <li>
+            <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id) }}">{{ attachment.display_name }}</a>
+            <span class="attachment-meta">Uploaded {{ attachment.uploaded_at.strftime('%b %d, %Y %H:%M') }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="empty">No attachments yet.</p>
+    {% endif %}
+  </section>
+
+  <section class="updates">
+    <h3>Updates</h3>
+    <ol class="timeline">
+      {% for update in ticket.updates|sort(attribute='created_at', reverse=true) %}
+        <li>
+          <div class="timeline-point"></div>
+          <div class="timeline-content">
+            <div class="update-meta">
+              <span class="author">{{ update.author or 'System' }}</span>
+              <span class="timestamp">{{ update.created_at.strftime('%b %d, %Y %H:%M') }}</span>
+              {% if update.status_from or update.status_to %}
+                <span class="status-change">{{ update.status_from or '—' }} → {{ update.status_to or '—' }}</span>
+              {% endif %}
+            </div>
+            <p>{{ update.body|urlize|replace('\n', '<br />')|safe }}</p>
+            {% if update.attachments %}
+              <ul class="update-attachments">
+                {% for attachment in update.attachments %}
+                  <li><a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id) }}">{{ attachment.display_name }}</a></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </div>
+        </li>
+      {% else %}
+        <li class="empty">No updates yet.</li>
+      {% endfor %}
+    </ol>
+  </section>
+</article>
+
+<section class="panel">
+  <h3>Add update</h3>
+  <form method="post" action="{{ url_for('tickets.add_update', ticket_id=ticket.id) }}" enctype="multipart/form-data" class="update-form">
+    <div class="field-group">
+      <label for="message">Message</label>
+      <textarea id="message" name="message" rows="4" placeholder="Share progress, blockers, or notes"></textarea>
+    </div>
+    <div class="field-group split">
+      <div>
+        <label for="author">Author</label>
+        <input type="text" id="author" name="author" placeholder="Optional" />
+      </div>
+      <div>
+        <label for="status">Status</label>
+        <select id="status" name="status">
+          {% for status in config.workflow %}
+            <option value="{{ status }}" {% if ticket.status == status %}selected{% endif %}>{{ status }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+    <div class="field-group" {% if ticket.status != 'On Hold' %}data-hidden{% endif %}>
+      <label for="on_hold_reason">On hold reason</label>
+      <select id="on_hold_reason" name="on_hold_reason">
+        <option value="">Select reason</option>
+        {% for reason in hold_reasons %}
+          <option value="{{ reason }}" {% if ticket.on_hold_reason == reason %}selected{% endif %}>{{ reason }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="field-group">
+      <label for="attachments">Attachments</label>
+      <input type="file" id="attachments" name="attachments" multiple />
+      <p class="help">Files are stored locally inside <code>{{ app_config.uploads_path }}</code>.</p>
+    </div>
+    <div class="actions">
+      <button type="submit" class="button primary">Add update</button>
+    </div>
+  </form>
+</section>
+<script>
+  const updateStatusSelect = document.getElementById('status');
+  const updateHoldGroup = document.querySelector('.update-form [data-hidden]');
+  const updateToggleHold = () => {
+    if (!updateHoldGroup) return;
+    if (updateStatusSelect && updateStatusSelect.value === 'On Hold') {
+      updateHoldGroup.removeAttribute('data-hidden');
+    } else {
+      updateHoldGroup.setAttribute('data-hidden', '');
+    }
+  };
+  if (updateStatusSelect) {
+    updateStatusSelect.addEventListener('change', updateToggleHold);
+    updateToggleHold();
+  }
+</script>
+{% endblock %}

--- a/templates/ticket_form.html
+++ b/templates/ticket_form.html
@@ -1,0 +1,100 @@
+{% extends "base.html" %}
+{% if ticket %}
+  {% set page_title = 'Edit Ticket' %}
+{% else %}
+  {% set page_title = 'New Ticket' %}
+{% endif %}
+{% block title %}{{ page_title }} · TicketTracker{% endblock %}
+{% block content %}
+<section class="panel">
+  <h2>{{ page_title }}</h2>
+  <form method="post" enctype="multipart/form-data" class="ticket-form">
+    <div class="field-group">
+      <label for="title">Title</label>
+      <input type="text" id="title" name="title" value="{{ ticket.title if ticket else '' }}" required />
+    </div>
+    <div class="field-group">
+      <label for="description">Description</label>
+      <textarea id="description" name="description" rows="6" required>{{ ticket.description if ticket else '' }}</textarea>
+    </div>
+    <div class="field-group split">
+      <div>
+        <label for="requester">Requester</label>
+        <input type="text" id="requester" name="requester" value="{{ ticket.requester if ticket else '' }}" />
+      </div>
+      <div>
+        <label for="watchers">Watchers (comma separated)</label>
+        <input type="text" id="watchers" name="watchers" value="{{ ticket.watchers|join(', ') if ticket else '' }}" />
+      </div>
+    </div>
+    <div class="field-group split">
+      <div>
+        <label for="priority">Priority</label>
+        <select id="priority" name="priority">
+          {% for priority in priorities %}
+            <option value="{{ priority }}" {% if ticket and ticket.priority == priority %}selected{% endif %}>{{ priority }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label for="status">Status</label>
+        <select id="status" name="status">
+          {% for status in workflow %}
+            <option value="{{ status }}" {% if ticket and ticket.status == status %}selected{% endif %}>{{ status }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+    <div class="field-group">
+      <label for="due_date">Due date</label>
+      <input type="datetime-local" id="due_date" name="due_date" value="{{ ticket.due_date.strftime('%Y-%m-%dT%H:%M') if ticket and ticket.due_date else '' }}" />
+    </div>
+    <div class="field-group" {% if not ticket or ticket.status != 'On Hold' %}data-hidden{% endif %}>
+      <label for="on_hold_reason">On hold reason</label>
+      <select id="on_hold_reason" name="on_hold_reason">
+        <option value="">Select reason</option>
+        {% for reason in hold_reasons %}
+          <option value="{{ reason }}" {% if ticket and ticket.on_hold_reason == reason %}selected{% endif %}>{{ reason }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="field-group">
+      <label for="tags">Tags</label>
+      <input type="text" id="tags" name="tags" value="{{ ticket.tag_names|join(', ') if ticket else '' }}" placeholder="Comma separated" />
+    </div>
+    <div class="field-group">
+      <label for="links">Links</label>
+      <textarea id="links" name="links" rows="2" placeholder="One link per line">{{ ticket.links if ticket else '' }}</textarea>
+    </div>
+    <div class="field-group">
+      <label for="notes">Private notes</label>
+      <textarea id="notes" name="notes" rows="3">{{ ticket.notes if ticket else '' }}</textarea>
+    </div>
+    <div class="field-group">
+      <label for="attachments">Attachments</label>
+      <input type="file" id="attachments" name="attachments" multiple />
+      <p class="help">Files upload into <code>{{ app_config.uploads_path }}</code>. Existing attachments stay unchanged.</p>
+    </div>
+    <div class="actions">
+      <button type="submit" class="button primary">Save</button>
+      <a class="button" href="{{ url_for('tickets.list_tickets') }}">Cancel</a>
+    </div>
+  </form>
+</section>
+<script>
+  const statusSelect = document.getElementById('status');
+  const holdGroup = document.querySelector('.ticket-form [data-hidden]');
+  const toggleHold = () => {
+    if (!holdGroup) return;
+    if (statusSelect && statusSelect.value === 'On Hold') {
+      holdGroup.removeAttribute('data-hidden');
+    } else {
+      holdGroup.setAttribute('data-hidden', '');
+    }
+  };
+  if (statusSelect) {
+    statusSelect.addEventListener('change', toggleHold);
+    toggleHold();
+  }
+</script>
+{% endblock %}

--- a/tickettracker/__init__.py
+++ b/tickettracker/__init__.py
@@ -1,0 +1,4 @@
+"""TicketTracker application package."""
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/tickettracker/app.py
+++ b/tickettracker/app.py
@@ -1,0 +1,49 @@
+"""Flask application factory for TicketTracker."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from flask import Flask
+
+from .config import AppConfig, load_config
+from .extensions import db
+
+
+def create_app(config_path: Optional[str | Path] = None) -> Flask:
+    """Create and configure the Flask application."""
+
+    app = Flask(__name__, instance_relative_config=True)
+    app_config: AppConfig = load_config(config_path)
+
+    app.config["SQLALCHEMY_DATABASE_URI"] = app_config.database_uri
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["UPLOAD_FOLDER"] = str(app_config.uploads_path)
+    app.config["APP_CONFIG"] = app_config
+
+    # Ensure the uploads directory exists before the first request.
+    uploads_path = app_config.uploads_path
+    uploads_path.mkdir(parents=True, exist_ok=True)
+
+    db.init_app(app)
+
+    with app.app_context():
+        # Import models so SQLAlchemy registers them, then create tables if needed.
+        from . import models  # noqa: F401
+
+        db.create_all()
+
+    from .views.tickets import tickets_bp
+
+    app.register_blueprint(tickets_bp)
+
+    @app.context_processor
+    def inject_app_config() -> dict[str, AppConfig]:
+        return {"app_config": app_config}
+
+    return app
+
+
+if __name__ == "__main__":
+    application = create_app()
+    application.run(debug=True)

--- a/tickettracker/config.py
+++ b/tickettracker/config.py
@@ -1,0 +1,167 @@
+"""Utilities for loading and working with TicketTracker configuration."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional
+
+DEFAULT_CONFIG_NAME = "config.json"
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "database": {"uri": "sqlite:///tickettracker.db"},
+    "uploads": {"directory": "uploads"},
+    "priorities": ["Low", "Medium", "High", "Urgent"],
+    "hold_reasons": [
+        "Awaiting customer response",
+        "Blocked by dependency",
+        "Pending scheduled work",
+        "Researching solution",
+    ],
+    "workflow": ["Open", "In Progress", "On Hold", "Resolved", "Closed", "Cancelled"],
+    "sla": {
+        "due_soon_hours": 24,
+        "overdue_grace_minutes": 0,
+        "priority_open_days": {"Low": 7, "Medium": 5, "High": 3, "Urgent": 1},
+    },
+    "colors": {
+        "gradient": {
+            "safe": "#1e90ff",
+            "warning": "#ffa502",
+            "overdue": "#ff4757",
+        },
+        "statuses": {
+            "on_hold": "#9c88ff",
+            "resolved": "#2ed573",
+            "closed": "#57606f",
+            "cancelled": "#747d8c",
+        },
+        "priorities": {
+            "Low": "#70a1ff",
+            "Medium": "#ffa502",
+            "High": "#ff6b81",
+            "Urgent": "#ff4757",
+        },
+        "tags": {
+            "background": "#2f3542",
+            "text": "#f1f2f6",
+        },
+    },
+}
+
+
+@dataclass
+class SLAConfig:
+    """Service-level agreement thresholds used for coloring tickets."""
+
+    due_soon_hours: int = 24
+    overdue_grace_minutes: int = 0
+    priority_open_days: Dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class ColorConfig:
+    """Color palette controls for different UI states."""
+
+    gradient: Dict[str, str] = field(default_factory=dict)
+    statuses: Dict[str, str] = field(default_factory=dict)
+    priorities: Dict[str, str] = field(default_factory=dict)
+    tags: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class AppConfig:
+    """Runtime configuration for the TicketTracker application."""
+
+    database_uri: str
+    uploads_directory: Path
+    priorities: List[str]
+    hold_reasons: List[str]
+    workflow: List[str]
+    sla: SLAConfig
+    colors: ColorConfig
+
+    @property
+    def uploads_path(self) -> Path:
+        return self.uploads_directory
+
+
+def _merge_dict(base: MutableMapping[str, Any], overlay: Mapping[str, Any]) -> MutableMapping[str, Any]:
+    for key, value in overlay.items():
+        if isinstance(value, Mapping) and isinstance(base.get(key), MutableMapping):
+            base[key] = _merge_dict(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def _resolve_database_uri(raw_uri: str, base_path: Path) -> str:
+    if raw_uri.startswith("sqlite:///") and not raw_uri.startswith("sqlite:////"):
+        relative_path = raw_uri.replace("sqlite:///", "", 1)
+        db_path = Path(relative_path)
+        if not db_path.is_absolute():
+            db_path = (base_path / db_path).resolve()
+        return f"sqlite:///{db_path}"
+    return raw_uri
+
+
+def _resolve_upload_directory(raw_directory: str, base_path: Path) -> Path:
+    upload_path = Path(raw_directory)
+    if not upload_path.is_absolute():
+        upload_path = (base_path / upload_path).resolve()
+    return upload_path
+
+
+def load_config(config_path: Optional[os.PathLike[str] | str] = None) -> AppConfig:
+    """Load application configuration from JSON, applying defaults as needed."""
+
+    provided_path = Path(config_path) if config_path else None
+    env_path = Path(os.environ["TICKETTRACKER_CONFIG"]) if "TICKETTRACKER_CONFIG" in os.environ else None
+
+    search_paths = [provided_path, env_path]
+    if provided_path is None and env_path is None:
+        search_paths.append(Path.cwd() / DEFAULT_CONFIG_NAME)
+        search_paths.append(Path(__file__).resolve().parent.parent / DEFAULT_CONFIG_NAME)
+
+    config_file: Optional[Path] = None
+    for candidate in search_paths:
+        if candidate and candidate.exists():
+            config_file = candidate
+            break
+
+    if config_file:
+        with config_file.open("r", encoding="utf-8") as fh:
+            loaded_data = json.load(fh)
+        base_path = config_file.parent
+    else:
+        loaded_data = {}
+        base_path = Path.cwd()
+
+    merged: Dict[str, Any] = json.loads(json.dumps(DEFAULT_CONFIG))  # deep copy
+    _merge_dict(merged, loaded_data)
+
+    sla_config = merged.get("sla", {})
+    colors_config = merged.get("colors", {})
+
+    database_uri = _resolve_database_uri(merged.get("database", {}).get("uri", "sqlite:///tickettracker.db"), base_path)
+    uploads_directory = _resolve_upload_directory(merged.get("uploads", {}).get("directory", "uploads"), base_path)
+
+    return AppConfig(
+        database_uri=database_uri,
+        uploads_directory=uploads_directory,
+        priorities=list(merged.get("priorities", [])),
+        hold_reasons=list(merged.get("hold_reasons", [])),
+        workflow=list(merged.get("workflow", [])),
+        sla=SLAConfig(
+            due_soon_hours=int(sla_config.get("due_soon_hours", 24)),
+            overdue_grace_minutes=int(sla_config.get("overdue_grace_minutes", 0)),
+            priority_open_days={k: int(v) for k, v in sla_config.get("priority_open_days", {}).items()},
+        ),
+        colors=ColorConfig(
+            gradient=dict(colors_config.get("gradient", {})),
+            statuses=dict(colors_config.get("statuses", {})),
+            priorities=dict(colors_config.get("priorities", {})),
+            tags=dict(colors_config.get("tags", {})),
+        ),
+    )

--- a/tickettracker/extensions.py
+++ b/tickettracker/extensions.py
@@ -1,0 +1,5 @@
+"""Application extensions for TicketTracker."""
+from flask_sqlalchemy import SQLAlchemy
+
+# SQLAlchemy database instance shared across the application.
+db = SQLAlchemy()

--- a/tickettracker/models.py
+++ b/tickettracker/models.py
@@ -1,0 +1,164 @@
+"""Database models for TicketTracker."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List, Sequence
+
+from sqlalchemy import event
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .extensions import db
+
+
+class TicketTag(db.Model):
+    """Association table between tickets and tags."""
+
+    __tablename__ = "ticket_tags"
+
+    ticket_id: Mapped[int] = mapped_column(db.Integer, db.ForeignKey("tickets.id"), primary_key=True)
+    tag_id: Mapped[int] = mapped_column(db.Integer, db.ForeignKey("tags.id"), primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class Ticket(db.Model):
+    """Primary ticket object representing a task or request."""
+
+    __tablename__ = "tickets"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    description: Mapped[str] = mapped_column(db.Text, nullable=False)
+    requester: Mapped[str | None] = mapped_column(db.String(120))
+    _watchers: Mapped[str | None] = mapped_column("watchers", db.Text)
+    priority: Mapped[str] = mapped_column(db.String(32), nullable=False, default="Medium")
+    status: Mapped[str] = mapped_column(db.String(32), nullable=False, default="Open")
+    due_date: Mapped[datetime | None] = mapped_column(db.DateTime)
+    notes: Mapped[str | None] = mapped_column(db.Text)
+    links: Mapped[str | None] = mapped_column(db.Text)
+    on_hold_reason: Mapped[str | None] = mapped_column(db.String(255))
+    created_at: Mapped[datetime] = mapped_column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    updates: Mapped[List["TicketUpdate"]] = relationship(
+        "TicketUpdate", back_populates="ticket", cascade="all, delete-orphan", order_by="TicketUpdate.created_at"
+    )
+    attachments: Mapped[List["Attachment"]] = relationship(
+        "Attachment", back_populates="ticket", cascade="all, delete-orphan"
+    )
+    tags: Mapped[List["Tag"]] = relationship("Tag", secondary="ticket_tags", back_populates="tickets")
+
+    @property
+    def watchers(self) -> List[str]:
+        if not self._watchers:
+            return []
+        return [part.strip() for part in self._watchers.split(",") if part.strip()]
+
+    @watchers.setter
+    def watchers(self, value: str | Sequence[str]) -> None:
+        if isinstance(value, str):
+            self._watchers = value
+        else:
+            self._watchers = ", ".join(part.strip() for part in value if part)
+
+    @property
+    def tag_names(self) -> List[str]:
+        return [tag.name for tag in self.tags]
+
+    def set_tags(self, tag_names: Iterable[str]) -> None:
+        normalized = {name.strip() for name in tag_names if name.strip()}
+        if not normalized:
+            self.tags = []
+            return
+
+        existing = {tag.name: tag for tag in Tag.query.filter(Tag.name.in_(normalized)).all()}
+
+        new_tags: List[Tag] = []
+        for name in normalized:
+            if name in existing:
+                new_tags.append(existing[name])
+            else:
+                tag = Tag(name=name)
+                db.session.add(tag)
+                new_tags.append(tag)
+        self.tags = new_tags
+
+    def add_update(
+        self,
+        message: str,
+        author: str | None = None,
+        status_from: str | None = None,
+        status_to: str | None = None,
+        is_system: bool = False,
+    ) -> "TicketUpdate":
+        update = TicketUpdate(
+            ticket=self,
+            body=message,
+            author=author,
+            status_from=status_from,
+            status_to=status_to,
+            is_system=is_system,
+        )
+        db.session.add(update)
+        self.updated_at = datetime.utcnow()
+        return update
+
+
+class TicketUpdate(db.Model):
+    """Chronological updates associated with a ticket."""
+
+    __tablename__ = "ticket_updates"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    ticket_id: Mapped[int] = mapped_column(db.Integer, db.ForeignKey("tickets.id"), nullable=False)
+    body: Mapped[str] = mapped_column(db.Text, nullable=False)
+    author: Mapped[str | None] = mapped_column(db.String(120))
+    created_at: Mapped[datetime] = mapped_column(db.DateTime, default=datetime.utcnow, nullable=False)
+    status_from: Mapped[str | None] = mapped_column(db.String(32))
+    status_to: Mapped[str | None] = mapped_column(db.String(32))
+    is_system: Mapped[bool] = mapped_column(db.Boolean, default=False, nullable=False)
+
+    ticket: Mapped[Ticket] = relationship("Ticket", back_populates="updates")
+    attachments: Mapped[List["Attachment"]] = relationship(
+        "Attachment", back_populates="update", cascade="all, delete-orphan"
+    )
+
+
+class Attachment(db.Model):
+    """Uploaded file stored on disk and linked to a ticket/update."""
+
+    __tablename__ = "attachments"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    ticket_id: Mapped[int] = mapped_column(db.Integer, db.ForeignKey("tickets.id"), nullable=False)
+    update_id: Mapped[int | None] = mapped_column(db.Integer, db.ForeignKey("ticket_updates.id"))
+    original_filename: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    stored_filename: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    mimetype: Mapped[str | None] = mapped_column(db.String(128))
+    size: Mapped[int | None] = mapped_column(db.Integer)
+    uploaded_at: Mapped[datetime] = mapped_column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    ticket: Mapped[Ticket] = relationship("Ticket", back_populates="attachments")
+    update: Mapped[TicketUpdate | None] = relationship("TicketUpdate", back_populates="attachments")
+
+    @property
+    def display_name(self) -> str:
+        return self.original_filename
+
+
+class Tag(db.Model):
+    """Reusable tag applied to tickets."""
+
+    __tablename__ = "tags"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(db.String(64), unique=True, nullable=False)
+    color: Mapped[str | None] = mapped_column(db.String(16))
+
+    tickets: Mapped[List[Ticket]] = relationship("Ticket", secondary="ticket_tags", back_populates="tags")
+
+
+@event.listens_for(Ticket, "before_update")
+def _touch_ticket(mapper, connection, target: Ticket) -> None:  # pragma: no cover - SQLAlchemy hook
+    target.updated_at = datetime.utcnow()

--- a/tickettracker/views/__init__.py
+++ b/tickettracker/views/__init__.py
@@ -1,0 +1,1 @@
+"""View blueprints for TicketTracker."""


### PR DESCRIPTION
## Summary
- add a Flask application factory with JSON-driven configuration, SQLAlchemy setup, and blueprint registration
- implement ticket, update, attachment, and tag models plus controllers for creation, editing, workflow transitions, and file downloads
- build responsive dark-mode templates, static styling, and configuration documentation alongside dependency pins

## Testing
- pytest