### PR TITLE
Configure Flask app to use repository templates and static files

### DIFF
--- a/tickettracker/app.py
+++ b/tickettracker/app.py
@@ -13,7 +13,13 @@ from .extensions import db
 def create_app(config_path: Optional[str | Path] = None) -> Flask:
     """Create and configure the Flask application."""
 
-    app = Flask(__name__, instance_relative_config=True)
+    repo_root = Path(__file__).resolve().parent.parent
+    app = Flask(
+        __name__,
+        instance_relative_config=True,
+        template_folder=str(repo_root / "templates"),
+        static_folder=str(repo_root / "static"),
+    )
     app_config: AppConfig = load_config(config_path)
 
     app.config["SQLALCHEMY_DATABASE_URI"] = app_config.database_uri


### PR DESCRIPTION
## Summary
- configure the Flask application factory to resolve the repository root
- pass the repository-level templates and static directories to the Flask constructor

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f900e0d7f0832c866af6140b7ec9c5