### PR TITLE
Add configurable Flask secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Runtime behaviour is driven by `config.json` in the project root. The file contr
 - workflow statuses, priorities, and hold reasons
 - SLA timing thresholds used for ticket colouring
 - palette overrides for statuses, priorities, and tag chips
+- Flask session secret (`secret_key`). For production deployments set the `TICKETTRACKER_SECRET_KEY` environment variable to override the value stored in the JSON file.
 
 You can provide a different configuration by setting `TICKETTRACKER_CONFIG` to an alternate JSON file path before starting the app.
 

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "secret_key": "dev-secret-key-change-me",
   "database": {
     "uri": "sqlite:///tickettracker.db"
   },

--- a/tickettracker/app.py
+++ b/tickettracker/app.py
@@ -22,6 +22,8 @@ def create_app(config_path: Optional[str | Path] = None) -> Flask:
     )
     app_config: AppConfig = load_config(config_path)
 
+    app.config["SECRET_KEY"] = app_config.secret_key
+
     app.config["SQLALCHEMY_DATABASE_URI"] = app_config.database_uri
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     app.config["UPLOAD_FOLDER"] = str(app_config.uploads_path)

--- a/tickettracker/config.py
+++ b/tickettracker/config.py
@@ -9,7 +9,11 @@ from typing import Any, Dict, List, Mapping, MutableMapping, Optional
 
 DEFAULT_CONFIG_NAME = "config.json"
 
+DEFAULT_SECRET_KEY = "dev-secret-key-change-me"
+
+
 DEFAULT_CONFIG: Dict[str, Any] = {
+    "secret_key": DEFAULT_SECRET_KEY,
     "database": {"uri": "sqlite:///tickettracker.db"},
     "uploads": {"directory": "uploads"},
     "priorities": ["Low", "Medium", "High", "Urgent"],
@@ -74,6 +78,7 @@ class ColorConfig:
 class AppConfig:
     """Runtime configuration for the TicketTracker application."""
 
+    secret_key: str
     database_uri: str
     uploads_directory: Path
     priorities: List[str]
@@ -146,8 +151,10 @@ def load_config(config_path: Optional[os.PathLike[str] | str] = None) -> AppConf
 
     database_uri = _resolve_database_uri(merged.get("database", {}).get("uri", "sqlite:///tickettracker.db"), base_path)
     uploads_directory = _resolve_upload_directory(merged.get("uploads", {}).get("directory", "uploads"), base_path)
+    secret_key = os.environ.get("TICKETTRACKER_SECRET_KEY") or str(merged.get("secret_key", DEFAULT_SECRET_KEY))
 
     return AppConfig(
+        secret_key=secret_key,
         database_uri=database_uri,
         uploads_directory=uploads_directory,
         priorities=list(merged.get("priorities", [])),


### PR DESCRIPTION
## Summary
- load the Flask secret key from configuration with optional environment overrides
- expose the configured secret to the application factory before extensions run
- document the secret key setting and provide a development key in the default config

## Testing
- pytest
- python -m compileall tickettracker

------
https://chatgpt.com/codex/tasks/task_e_68f9055d72c4832c915612161c3bc942