### PR TITLE
Add priority badges and update default palette

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
   "uploads": {
     "directory": "uploads"
   },
-  "priorities": ["Low", "Medium", "High", "Urgent"],
+  "priorities": ["Low", "Medium", "High", "Critical"],
   "hold_reasons": [
     "Awaiting customer response",
     "Blocked by dependency",
@@ -21,7 +21,7 @@
       "Low": 7,
       "Medium": 5,
       "High": 3,
-      "Urgent": 1
+      "Critical": 1
     }
   },
   "colors": {
@@ -37,10 +37,10 @@
       "cancelled": "#64748b"
     },
     "priorities": {
-      "Low": "#34d399",
+      "Low": "#3b82f6",
       "Medium": "#facc15",
-      "High": "#fb7185",
-      "Urgent": "#f43f5e"
+      "High": "#f97316",
+      "Critical": "#ef4444"
     },
     "tags": {
       "background": "#1e293b",

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -241,20 +241,33 @@ a:hover {
   color: var(--text-muted);
 }
 
-.priority[data-priority='Urgent'] {
-  color: #fda4af;
+.priority {
+  display: inline-flex;
 }
 
-.priority[data-priority='High'] {
-  color: #fca5a5;
+.priority-badge {
+  --priority-color: rgba(148, 163, 184, 0.25);
+  --priority-text: #0f172a;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--priority-color);
+  color: var(--priority-text);
+  text-shadow: 0 1px 2px rgba(15, 23, 42, 0.3);
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.35), 0 8px 16px rgba(2, 6, 23, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.priority[data-priority='Medium'] {
-  color: #facc15;
-}
-
-.priority[data-priority='Low'] {
-  color: #34d399;
+.priority-badge[data-priority]:hover,
+.priority-badge[data-priority]:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.45), 0 12px 28px rgba(2, 6, 23, 0.45);
 }
 
 .ticket-card .timestamps,

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,7 +62,16 @@
             <h2><a href="{{ url_for('tickets.ticket_detail', ticket_id=ticket.id) }}">{{ ticket.title }}</a></h2>
             <div class="meta">
               <span class="status">{{ ticket.status }}{% if ticket.status == 'On Hold' and ticket.on_hold_reason %} · {{ ticket.on_hold_reason }}{% endif %}</span>
-              <span class="priority" data-priority="{{ ticket.priority }}">{{ ticket.priority }}</span>
+              {% set priority_color = config.colors.priorities.get(ticket.priority, '#3b82f6') %}
+              <span class="priority">
+                <span
+                  class="priority-badge"
+                  data-priority="{{ ticket.priority }}"
+                  style="--priority-color: {{ priority_color }};"
+                >
+                  {{ ticket.priority }}
+                </span>
+              </span>
               {% if ticket.due_date %}
                 <span class="due">Due {{ ticket.due_date.strftime('%b %d, %Y %H:%M') }}</span>
               {% else %}

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -7,7 +7,16 @@
       <h2>{{ ticket.title }}</h2>
       <div class="meta">
         <span class="status">{{ ticket.status }}{% if ticket.status == 'On Hold' and ticket.on_hold_reason %} · {{ ticket.on_hold_reason }}{% endif %}</span>
-        <span class="priority" data-priority="{{ ticket.priority }}">{{ ticket.priority }}</span>
+        {% set priority_color = config.colors.priorities.get(ticket.priority, '#3b82f6') %}
+        <span class="priority">
+          <span
+            class="priority-badge"
+            data-priority="{{ ticket.priority }}"
+            style="--priority-color: {{ priority_color }};"
+          >
+            {{ ticket.priority }}
+          </span>
+        </span>
         {% if ticket.due_date %}
           <span class="due">Due {{ ticket.due_date.strftime('%b %d, %Y %H:%M') }}</span>
         {% else %}

--- a/tickettracker/config.py
+++ b/tickettracker/config.py
@@ -16,7 +16,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "secret_key": DEFAULT_SECRET_KEY,
     "database": {"uri": "sqlite:///tickettracker.db"},
     "uploads": {"directory": "uploads"},
-    "priorities": ["Low", "Medium", "High", "Urgent"],
+    "priorities": ["Low", "Medium", "High", "Critical"],
     "hold_reasons": [
         "Awaiting customer response",
         "Blocked by dependency",
@@ -27,7 +27,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "sla": {
         "due_soon_hours": 24,
         "overdue_grace_minutes": 0,
-        "priority_open_days": {"Low": 7, "Medium": 5, "High": 3, "Urgent": 1},
+        "priority_open_days": {"Low": 7, "Medium": 5, "High": 3, "Critical": 1},
     },
     "colors": {
         "gradient": {
@@ -42,10 +42,10 @@ DEFAULT_CONFIG: Dict[str, Any] = {
             "cancelled": "#747d8c",
         },
         "priorities": {
-            "Low": "#70a1ff",
-            "Medium": "#ffa502",
-            "High": "#ff6b81",
-            "Urgent": "#ff4757",
+            "Low": "#3b82f6",
+            "Medium": "#facc15",
+            "High": "#f97316",
+            "Critical": "#ef4444",
         },
         "tags": {
             "background": "#2f3542",


### PR DESCRIPTION
## Summary
- update the default priority names to Low/Medium/High/Critical with new default SLA thresholds and palette entries
- wrap ticket priority displays in a dedicated badge that sources its background colour from the configuration
- style the badge component so custom priority colours flow through via CSS custom properties

## Testing
- pytest
- flake8 *(fails: tool unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f91ac7cf74832cb3a544cf2ae4c954