### PR TITLE
Implement staged SLA thresholds and gradient palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Runtime behaviour is driven by `config.json` in the project root. The file contr
 - palette overrides for statuses, priorities, and tag chips
 - Flask session secret (`secret_key`). For production deployments set the `TICKETTRACKER_SECRET_KEY` environment variable to override the value stored in the JSON file.
 
+SLA configuration now works in stages. For due dates, the `sla.due_stage_days` list expresses the day thresholds (defaults: 28/21/14/7) that map to the gradient stages. Tickets transition from stage 0 when they are far from the due date through stages 1–3 as they approach it, and finally to the `overdue` colour once the due date passes. Backlog items without due dates use `sla.priority_stage_days`, where each priority has an array of ascending day limits; once a ticket ages beyond the final value it is treated as overdue.
+
+The gradient palette exposes five keys—`stage0`, `stage1`, `stage2`, `stage3`, and `overdue`. By default the colours flow from a light blue baseline through yellow and orange to red and finally crimson for overdue tickets. Custom configurations may omit individual entries; any missing colours fall back to the defaults above.
+
 You can provide a different configuration by setting `TICKETTRACKER_CONFIG` to an alternate JSON file path before starting the app.
 
 ### Running the development server

--- a/config.json
+++ b/config.json
@@ -15,20 +15,21 @@
   ],
   "workflow": ["Open", "In Progress", "On Hold", "Resolved", "Closed", "Cancelled"],
   "sla": {
-    "due_soon_hours": 24,
-    "overdue_grace_minutes": 30,
-    "priority_open_days": {
-      "Low": 7,
-      "Medium": 5,
-      "High": 3,
-      "Critical": 1
+    "due_stage_days": [28, 21, 14, 7],
+    "priority_stage_days": {
+      "Low": [14, 21, 28, 35],
+      "Medium": [10, 15, 20, 25],
+      "High": [5, 7, 10, 14],
+      "Critical": [2, 3, 5, 7]
     }
   },
   "colors": {
     "gradient": {
-      "safe": "#38bdf8",
-      "warning": "#facc15",
-      "overdue": "#f87171"
+      "stage0": "#bae6fd",
+      "stage1": "#fde047",
+      "stage2": "#fb923c",
+      "stage3": "#ef4444",
+      "overdue": "#7f1d1d"
     },
     "statuses": {
       "on_hold": "#9c88ff",

--- a/tickettracker/config.py
+++ b/tickettracker/config.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -10,6 +11,26 @@ from typing import Any, Dict, List, Mapping, MutableMapping, Optional
 DEFAULT_CONFIG_NAME = "config.json"
 
 DEFAULT_SECRET_KEY = "dev-secret-key-change-me"
+
+
+GRADIENT_STAGE_ORDER: List[str] = ["stage0", "stage1", "stage2", "stage3"]
+GRADIENT_OVERDUE_KEY = "overdue"
+DEFAULT_GRADIENT_COLORS: Dict[str, str] = {
+    "stage0": "#bae6fd",
+    "stage1": "#fde047",
+    "stage2": "#fb923c",
+    "stage3": "#ef4444",
+    GRADIENT_OVERDUE_KEY: "#7f1d1d",
+}
+
+DEFAULT_DUE_STAGE_DAYS: List[int] = [28, 21, 14, 7]
+DEFAULT_PRIORITY_STAGE_DAYS: Dict[str, List[int]] = {
+    "Low": [14, 21, 28, 35],
+    "Medium": [10, 15, 20, 25],
+    "High": [5, 7, 10, 14],
+    "Critical": [2, 3, 5, 7],
+}
+DEFAULT_PRIORITY_STAGE_DAYS_FALLBACK: List[int] = [7, 14, 21, 28]
 
 
 DEFAULT_CONFIG: Dict[str, Any] = {
@@ -25,15 +46,12 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     ],
     "workflow": ["Open", "In Progress", "On Hold", "Resolved", "Closed", "Cancelled"],
     "sla": {
-        "due_soon_hours": 24,
-        "overdue_grace_minutes": 0,
-        "priority_open_days": {"Low": 7, "Medium": 5, "High": 3, "Critical": 1},
+        "due_stage_days": DEFAULT_DUE_STAGE_DAYS,
+        "priority_stage_days": DEFAULT_PRIORITY_STAGE_DAYS,
     },
     "colors": {
         "gradient": {
-            "safe": "#1e90ff",
-            "warning": "#ffa502",
-            "overdue": "#ff4757",
+            **DEFAULT_GRADIENT_COLORS,
         },
         "statuses": {
             "on_hold": "#9c88ff",
@@ -59,9 +77,32 @@ DEFAULT_CONFIG: Dict[str, Any] = {
 class SLAConfig:
     """Service-level agreement thresholds used for coloring tickets."""
 
-    due_soon_hours: int = 24
-    overdue_grace_minutes: int = 0
-    priority_open_days: Dict[str, int] = field(default_factory=dict)
+    due_stage_days: List[int] = field(default_factory=list)
+    priority_stage_days: Dict[str, List[int]] = field(default_factory=dict)
+
+    def due_thresholds(self) -> List[int]:
+        """Return descending day thresholds for due-date staging."""
+
+        thresholds = [day for day in self.due_stage_days if isinstance(day, int)]
+        thresholds.sort(reverse=True)
+        return thresholds or list(DEFAULT_DUE_STAGE_DAYS)
+
+    def priority_thresholds(self, priority: str) -> List[int]:
+        """Return ascending day thresholds for backlog staging by priority."""
+
+        raw_thresholds = self.priority_stage_days.get(priority)
+        if raw_thresholds:
+            thresholds = [day for day in raw_thresholds if isinstance(day, int)]
+            thresholds = [day for day in thresholds if day >= 0]
+            thresholds.sort()
+            if thresholds:
+                return thresholds
+
+        default_thresholds = DEFAULT_PRIORITY_STAGE_DAYS.get(priority)
+        if default_thresholds:
+            return list(default_thresholds)
+
+        return list(DEFAULT_PRIORITY_STAGE_DAYS_FALLBACK)
 
 
 @dataclass
@@ -72,6 +113,19 @@ class ColorConfig:
     statuses: Dict[str, str] = field(default_factory=dict)
     priorities: Dict[str, str] = field(default_factory=dict)
     tags: Dict[str, str] = field(default_factory=dict)
+
+    def gradient_color(self, key: str) -> str:
+        if key in DEFAULT_GRADIENT_COLORS:
+            return self.gradient.get(key, DEFAULT_GRADIENT_COLORS[key])
+        return self.gradient.get(key, DEFAULT_GRADIENT_COLORS[GRADIENT_STAGE_ORDER[0]])
+
+    def gradient_stage_color(self, stage_index: int) -> str:
+        bounded_index = max(0, min(stage_index, len(GRADIENT_STAGE_ORDER) - 1))
+        key = GRADIENT_STAGE_ORDER[bounded_index]
+        return self.gradient_color(key)
+
+    def gradient_overdue_color(self) -> str:
+        return self.gradient_color(GRADIENT_OVERDUE_KEY)
 
 
 @dataclass
@@ -90,6 +144,27 @@ class AppConfig:
     @property
     def uploads_path(self) -> Path:
         return self.uploads_directory
+
+
+def _coerce_non_negative_int(value: Any) -> Optional[int]:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    if number < 0:
+        return None
+    return number
+
+
+def _legacy_stage_thresholds(limit: int) -> List[int]:
+    if limit <= 0:
+        return []
+
+    quarter = max(1, math.ceil(limit / 4))
+    half = max(quarter, math.ceil(limit / 2))
+    three_quarter = max(half, math.ceil(limit * 3 / 4))
+    final = max(three_quarter, limit)
+    return [quarter, half, three_quarter, final]
 
 
 def _merge_dict(base: MutableMapping[str, Any], overlay: Mapping[str, Any]) -> MutableMapping[str, Any]:
@@ -149,6 +224,40 @@ def load_config(config_path: Optional[os.PathLike[str] | str] = None) -> AppConf
     sla_config = merged.get("sla", {})
     colors_config = merged.get("colors", {})
 
+    raw_due_stage_days = sla_config.get("due_stage_days", [])
+    due_stage_days: List[int] = []
+    if isinstance(raw_due_stage_days, (list, tuple)):
+        for value in raw_due_stage_days:
+            coerced = _coerce_non_negative_int(value)
+            if coerced is not None:
+                due_stage_days.append(coerced)
+
+    raw_priority_stage_days = sla_config.get("priority_stage_days", {})
+    priority_stage_days: Dict[str, List[int]] = {}
+    if isinstance(raw_priority_stage_days, Mapping):
+        for priority, values in raw_priority_stage_days.items():
+            if not isinstance(values, (list, tuple)):
+                continue
+            sanitized: List[int] = []
+            for value in values:
+                coerced = _coerce_non_negative_int(value)
+                if coerced is not None:
+                    sanitized.append(coerced)
+            if sanitized:
+                priority_stage_days[str(priority)] = sanitized
+
+    legacy_priority_open = sla_config.get("priority_open_days", {})
+    if isinstance(legacy_priority_open, Mapping):
+        for priority, value in legacy_priority_open.items():
+            coerced = _coerce_non_negative_int(value)
+            if coerced is None:
+                continue
+            priority_key = str(priority)
+            if priority_key not in priority_stage_days:
+                thresholds = _legacy_stage_thresholds(coerced)
+                if thresholds:
+                    priority_stage_days[priority_key] = thresholds
+
     database_uri = _resolve_database_uri(merged.get("database", {}).get("uri", "sqlite:///tickettracker.db"), base_path)
     uploads_directory = _resolve_upload_directory(merged.get("uploads", {}).get("directory", "uploads"), base_path)
     secret_key = os.environ.get("TICKETTRACKER_SECRET_KEY") or str(merged.get("secret_key", DEFAULT_SECRET_KEY))
@@ -161,9 +270,8 @@ def load_config(config_path: Optional[os.PathLike[str] | str] = None) -> AppConf
         hold_reasons=list(merged.get("hold_reasons", [])),
         workflow=list(merged.get("workflow", [])),
         sla=SLAConfig(
-            due_soon_hours=int(sla_config.get("due_soon_hours", 24)),
-            overdue_grace_minutes=int(sla_config.get("overdue_grace_minutes", 0)),
-            priority_open_days={k: int(v) for k, v in sla_config.get("priority_open_days", {}).items()},
+            due_stage_days=due_stage_days,
+            priority_stage_days=priority_stage_days,
         ),
         colors=ColorConfig(
             gradient=dict(colors_config.get("gradient", {})),


### PR DESCRIPTION
## Summary
- add stage-based SLA thresholds and fallback handling in the configuration loader
- update the default gradient palette and ticket colour logic to use staged keys
- document the new configuration fields for administrators

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f91c7fef48832c98ffdbfaddcf1b6d