### PR TITLE
Expose ticket accent tint variables in ticket UI

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -202,7 +202,12 @@ a:hover {
 }
 
 .ticket-card {
-  background: linear-gradient(145deg, rgba(17, 24, 39, 0.95), rgba(15, 23, 42, 0.85));
+  background: linear-gradient(
+    145deg,
+    var(--ticket-tint, rgba(56, 189, 248, 0.2)) 0%,
+    rgba(15, 23, 42, 0.9) 55%,
+    rgba(15, 23, 42, 0.85) 100%
+  );
   border-radius: 1.5rem;
   padding: 1.5rem;
   border: 1px solid rgba(148, 163, 184, 0.08);
@@ -337,7 +342,12 @@ a:hover {
 }
 
 .ticket-detail {
-  background: linear-gradient(145deg, rgba(17, 24, 39, 0.95), rgba(30, 41, 59, 0.75));
+  background: linear-gradient(
+    155deg,
+    var(--ticket-tint, rgba(56, 189, 248, 0.22)) 0%,
+    rgba(17, 24, 39, 0.92) 50%,
+    rgba(15, 23, 42, 0.78) 100%
+  );
   padding: 2rem;
   border-radius: 1.75rem;
   border: 1px solid rgba(148, 163, 184, 0.1);

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,7 +56,7 @@
 <section class="ticket-grid">
   {% if tickets %}
     {% for ticket in tickets %}
-      <article class="ticket-card" style="--ticket-accent: {{ ticket.display_color }};">
+      <article class="ticket-card" style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};">
         <header>
           <div class="title-group">
             <h2><a href="{{ url_for('tickets.ticket_detail', ticket_id=ticket.id) }}">{{ ticket.title }}</a></h2>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ ticket.title }} · TicketTracker{% endblock %}
 {% block content %}
-<article class="ticket-detail" style="--ticket-accent: {{ ticket.display_color }};">
+<article class="ticket-detail" style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};">
   <header>
     <div class="title-group">
       <h2>{{ ticket.title }}</h2>


### PR DESCRIPTION
## Summary
- derive a reusable 25% tint for each ticket accent color
- surface the accent and tint variables to the ticket list and detail templates
- restyle ticket card and detail backgrounds to incorporate the ticket tint while keeping status borders

## Testing
- pytest
- python -m compileall tickettracker

------
https://chatgpt.com/codex/tasks/task_e_68f9200d6a68832c8acbe1dbc57e5975