### PR TITLE
Add collapsible filters and button-based sorting

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -142,6 +142,146 @@ a:hover {
   gap: 1.25rem;
 }
 
+.filter-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.filter-collapsible {
+  flex: 1 1 360px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 1rem;
+  padding: 0.85rem 1.1rem;
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+}
+
+.filter-collapsible > summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.filter-collapsible > summary:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.6);
+  outline-offset: 4px;
+  border-radius: 0.75rem;
+}
+
+.filter-collapsible > summary::-webkit-details-marker {
+  display: none;
+}
+
+.filter-collapsible[open] {
+  border-color: rgba(56, 189, 248, 0.4);
+  box-shadow: 0 12px 32px rgba(2, 6, 23, 0.35);
+}
+
+.filter-fields {
+  margin-top: 1rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.filter-indicator {
+  color: var(--accent);
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.sort-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.6rem;
+  min-width: 220px;
+}
+
+.sort-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.sort-button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.sort-button {
+  appearance: none;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.5);
+  color: var(--text);
+  padding: 0.5rem 0.9rem;
+  border-radius: 0.75rem;
+  font: inherit;
+  cursor: pointer;
+  transition: border 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.sort-button:hover,
+.sort-button:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.65);
+  color: #f8fafc;
+}
+
+.sort-button.is-active {
+  background: rgba(56, 189, 248, 0.25);
+  border-color: rgba(56, 189, 248, 0.65);
+  color: #f8fafc;
+  box-shadow: 0 8px 22px rgba(2, 6, 23, 0.35);
+}
+
+.sort-button.is-active::after {
+  content: '↑';
+  margin-left: 0.35rem;
+  font-size: 0.75rem;
+  opacity: 0.9;
+}
+
+.sort-button.is-active.is-desc::after,
+.sort-button.is-active[data-order='desc']::after {
+  content: '↓';
+}
+
+@media (max-width: 720px) {
+  .filter-toolbar {
+    flex-direction: column;
+  }
+
+  .sort-controls {
+    width: 100%;
+  }
+
+  .sort-button-group {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
 .field-group {
   display: flex;
   flex-direction: column;

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,49 +2,89 @@
 {% block title %}Tickets · TicketTracker{% endblock %}
 {% block content %}
 <section class="panel">
-  <form method="get" class="filter-form">
-    <div class="field-group">
-      <label for="search">Search</label>
-      <input type="search" id="search" name="q" placeholder="Search tickets" value="{{ filters.search or '' }}" />
-    </div>
-    <div class="field-group">
-      <label for="status">Status</label>
-      <select id="status" name="status">
-        <option value="">All</option>
-        {% for status in config.workflow %}
-          <option value="{{ status }}" {% if filters.status == status %}selected{% endif %}>{{ status }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div class="field-group">
-      <label for="priority">Priority</label>
-      <select id="priority" name="priority">
-        <option value="">All</option>
-        {% for priority in priorities %}
-          <option value="{{ priority }}" {% if filters.priority == priority %}selected{% endif %}>{{ priority }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div class="field-group">
-      <label for="tag">Tags</label>
-      <select id="tag" name="tag" multiple size="3">
-        {% for tag in available_tags %}
-          <option value="{{ tag.name }}" {% if tag.name in filters.tags %}selected{% endif %}>{{ tag.name }}</option>
-        {% endfor %}
-      </select>
-      <div class="tag-mode">
-        <label><input type="radio" name="tag_mode" value="any" {% if filters.tag_mode != 'all' %}checked{% endif %} /> Any</label>
-        <label><input type="radio" name="tag_mode" value="all" {% if filters.tag_mode == 'all' %}checked{% endif %} /> All</label>
+  <form method="get" class="filter-form" data-filter-form>
+    <div class="filter-toolbar">
+      <details
+        class="filter-collapsible"
+        data-filter-collapsible
+        data-has-active="{{ 'true' if filters.has_active_filters else 'false' }}"
+        {% if filters.has_active_filters %}open{% endif %}
+      >
+        <summary class="filter-toggle">
+          <span>Filters</span>
+          {% if filters.has_active_filters %}
+            <span class="filter-indicator" aria-hidden="true">•</span>
+            <span class="sr-only">Active filters applied</span>
+          {% endif %}
+        </summary>
+        <div class="filter-fields">
+          <div class="field-group">
+            <label for="search">Search</label>
+            <input type="search" id="search" name="q" placeholder="Search tickets" value="{{ filters.search or '' }}" />
+          </div>
+          <div class="field-group">
+            <label for="status">Status</label>
+            <select id="status" name="status">
+              <option value="">All</option>
+              {% for status in config.workflow %}
+                <option value="{{ status }}" {% if filters.status == status %}selected{% endif %}>{{ status }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="field-group">
+            <label for="priority">Priority</label>
+            <select id="priority" name="priority">
+              <option value="">All</option>
+              {% for priority in priorities %}
+                <option value="{{ priority }}" {% if filters.priority == priority %}selected{% endif %}>{{ priority }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="field-group">
+            <label for="tag">Tags</label>
+            <select id="tag" name="tag" multiple size="3">
+              {% for tag in available_tags %}
+                <option value="{{ tag.name }}" {% if tag.name in filters.tags %}selected{% endif %}>{{ tag.name }}</option>
+              {% endfor %}
+            </select>
+            <div class="tag-mode">
+              <label><input type="radio" name="tag_mode" value="any" {% if filters.tag_mode != 'all' %}checked{% endif %} /> Any</label>
+              <label><input type="radio" name="tag_mode" value="all" {% if filters.tag_mode == 'all' %}checked{% endif %} /> All</label>
+            </div>
+          </div>
+        </div>
+      </details>
+      <div class="sort-controls" data-sort-controls>
+        <span class="sort-label">Sort by</span>
+        <div class="sort-button-group" role="group" aria-label="Sort tickets">
+          {% set sort_order = filters.order %}
+          {% set active_sort = filters.sort %}
+          {% set defaults = {'due': 'asc', 'priority': 'asc', 'updated': 'desc', 'created': 'desc'} %}
+          {% set buttons = [
+            ('due', 'Due'),
+            ('priority', 'Priority'),
+            ('updated', 'Updated'),
+            ('created', 'Created')
+          ] %}
+          {% for value, label in buttons %}
+            {% set is_active = active_sort == value %}
+            {% set button_order = sort_order if is_active else defaults[value] %}
+            <button
+              type="submit"
+              name="sort"
+              value="{{ value }}"
+              class="sort-button{% if is_active %} is-active{% endif %}{% if is_active and sort_order == 'desc' %} is-desc{% endif %}"
+              data-sort-button
+              data-default-order="{{ defaults[value] }}"
+              data-order="{{ button_order }}"
+              aria-pressed="{{ 'true' if is_active else 'false' }}"
+            >
+              {{ label }}
+            </button>
+          {% endfor %}
+        </div>
+        <input type="hidden" name="order" value="{{ filters.order }}" data-sort-order />
       </div>
-    </div>
-    <div class="field-group">
-      <label for="sort">Sort</label>
-      <select id="sort" name="sort">
-        <option value="due" {% if filters.sort == 'due' %}selected{% endif %}>Due date</option>
-        <option value="priority" {% if filters.sort == 'priority' %}selected{% endif %}>Priority</option>
-        <option value="updated" {% if filters.sort == 'updated' %}selected{% endif %}>Recently updated</option>
-        <option value="created" {% if filters.sort == 'created' %}selected{% endif %}>Newest</option>
-      </select>
     </div>
     <div class="actions">
       <button type="submit" class="button primary">Apply</button>
@@ -124,4 +164,64 @@
     </div>
   {% endif %}
 </section>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const filterDetails = document.querySelector('[data-filter-collapsible]');
+    if (filterDetails) {
+      const storageKey = 'tickettracker:filters:collapsed';
+      const hasActive = filterDetails.getAttribute('data-has-active') === 'true';
+      try {
+        const storedState = window.localStorage.getItem(storageKey);
+        if (storedState === 'open') {
+          filterDetails.setAttribute('open', '');
+        } else if (storedState === 'closed') {
+          filterDetails.removeAttribute('open');
+        } else if (hasActive) {
+          filterDetails.setAttribute('open', '');
+        }
+      } catch (error) {
+        if (hasActive) {
+          filterDetails.setAttribute('open', '');
+        }
+      }
+
+      filterDetails.addEventListener('toggle', function () {
+        try {
+          window.localStorage.setItem(
+            storageKey,
+            filterDetails.open ? 'open' : 'closed',
+          );
+        } catch (error) {
+          /* ignore persistence errors */
+        }
+      });
+    }
+
+    const orderInput = document.querySelector('[data-sort-order]');
+    const sortButtons = document.querySelectorAll('[data-sort-button]');
+    sortButtons.forEach(function (button) {
+      button.addEventListener('click', function () {
+        if (!orderInput) {
+          return;
+        }
+
+        const isActive = button.classList.contains('is-active');
+        if (isActive) {
+          const nextOrder = orderInput.value === 'asc' ? 'desc' : 'asc';
+          orderInput.value = nextOrder;
+          button.setAttribute('data-order', nextOrder);
+          button.classList.toggle('is-desc', nextOrder === 'desc');
+        } else {
+          const defaultOrder = button.getAttribute('data-default-order');
+          if (defaultOrder) {
+            orderInput.value = defaultOrder;
+            button.classList.toggle('is-desc', defaultOrder === 'desc');
+            button.setAttribute('data-order', defaultOrder);
+          }
+        }
+      });
+    });
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- wrap the ticket filters in a collapsible container and persist its state with unobtrusive JS
- replace the sort dropdown with a four-button group that toggles direction and surfaces the chosen sort order
- teach the ticket list view to honour the new `order` parameter and style the refreshed controls

## Testing
- pytest
- python -m compileall tickettracker

------
https://chatgpt.com/codex/tasks/task_e_68f9221c4550832c83245fe197f044e1