### PR TITLE
Add compact layout toggle and styles

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -102,6 +102,211 @@ a:hover {
   flex: 1;
 }
 
+.nav-links .toggle-compact {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Compact mode adjustments */
+body.compact {
+  font-size: 0.95rem;
+}
+
+body.compact .app-header {
+  padding: 1.1rem 4vw;
+}
+
+body.compact .brand .logo {
+  font-size: 1.6rem;
+}
+
+body.compact .nav-links {
+  gap: 0.75rem;
+}
+
+body.compact .button {
+  padding: 0.5rem 1rem;
+  border-radius: 0.65rem;
+}
+
+body.compact .nav-links .button {
+  padding: 0.45rem 0.95rem;
+}
+
+body.compact .nav-links .button.primary {
+  padding: 0.45rem 1.05rem;
+}
+
+body.compact .content {
+  width: min(1024px, 95vw);
+  margin: 1.5rem auto 3rem;
+}
+
+body.compact .panel {
+  padding: 1.25rem;
+  border-radius: 1.35rem;
+  margin-bottom: 1.5rem;
+}
+
+body.compact .filter-form,
+body.compact .ticket-form,
+body.compact .update-form {
+  gap: 0.9rem;
+}
+
+body.compact .filter-toolbar {
+  gap: 1rem;
+}
+
+body.compact .filter-collapsible {
+  padding: 0.75rem 0.95rem;
+  border-radius: 0.9rem;
+}
+
+body.compact .filter-fields {
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+body.compact .sort-controls {
+  gap: 0.45rem;
+}
+
+body.compact .sort-button-group {
+  gap: 0.4rem;
+}
+
+body.compact .sort-button {
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.65rem;
+}
+
+body.compact .field-group {
+  gap: 0.4rem;
+}
+
+body.compact .field-group label {
+  font-size: 0.8rem;
+}
+
+body.compact .field-group input,
+body.compact .field-group textarea,
+body.compact .field-group select {
+  padding: 0.65rem 0.9rem;
+  border-radius: 0.65rem;
+}
+
+body.compact .field-group.split {
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+body.compact .tag-mode {
+  gap: 0.75rem;
+  font-size: 0.8rem;
+}
+
+body.compact .actions {
+  gap: 0.6rem;
+}
+
+body.compact .ticket-grid {
+  gap: 1rem;
+}
+
+body.compact .ticket-card {
+  padding: 1.1rem;
+  border-radius: 1.25rem;
+}
+
+body.compact .ticket-card header,
+body.compact .ticket-detail > header {
+  gap: 1rem;
+}
+
+body.compact .ticket-card .description {
+  margin-top: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+body.compact .ticket-details {
+  gap: 0.75rem;
+}
+
+body.compact .ticket-details div {
+  padding: 0.6rem;
+  border-radius: 0.65rem;
+}
+
+body.compact .tags {
+  gap: 0.4rem;
+}
+
+body.compact .tags li {
+  padding: 0.3rem 0.55rem;
+  font-size: 0.7rem;
+}
+
+body.compact .ticket-card footer {
+  margin-top: 1rem;
+  font-size: 0.75rem;
+}
+
+body.compact .ticket-detail {
+  padding: 1.6rem;
+  border-radius: 1.5rem;
+  margin-bottom: 1.75rem;
+}
+
+body.compact .detail-grid {
+  gap: 1.5rem;
+}
+
+body.compact .detail-grid aside dl {
+  gap: 0.75rem;
+}
+
+body.compact .timeline {
+  margin: 1.5rem 0 0;
+}
+
+body.compact .timeline li {
+  padding-left: 2.25rem;
+  margin-bottom: 1.3rem;
+}
+
+body.compact .timeline-content {
+  padding: 0.85rem;
+  border-radius: 0.9rem;
+}
+
+body.compact .update-meta {
+  gap: 0.4rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+body.compact .empty-state,
+body.compact .timeline li.empty,
+body.compact .attachments .empty {
+  padding: 1.5rem;
+}
+
+body.compact .flash-container {
+  gap: 0.6rem;
+  margin-bottom: 1.25rem;
+}
+
+body.compact .flash {
+  padding: 0.7rem 1rem;
+  border-radius: 0.75rem;
+}
+
+body.compact .app-footer {
+  padding: 1.5rem 4vw;
+  font-size: 0.8rem;
+}
+
 .button {
   display: inline-flex;
   align-items: center;

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,8 @@
       rel="stylesheet"
     />
   </head>
-  <body>
+  {% set is_compact = compact_mode|default(false) %}
+  <body class="{% if is_compact %}compact{% endif %}">
     <header class="app-header">
       <div class="brand">
         <span class="logo">🎫</span>
@@ -22,8 +23,21 @@
         </div>
       </div>
       <nav class="nav-links">
-        <a href="{{ url_for('tickets.list_tickets') }}">Tickets</a>
-        <a href="{{ url_for('tickets.create_ticket') }}" class="button primary">New Ticket</a>
+        <a href="{{ url_for('tickets.list_tickets', compact='1') if is_compact else url_for('tickets.list_tickets') }}">Tickets</a>
+        <a
+          href="{{ url_for('tickets.create_ticket', compact='1') if is_compact else url_for('tickets.create_ticket') }}"
+          class="button primary"
+        >
+          New Ticket
+        </a>
+        <a
+          href="{{ compact_toggle_url|default(request.url) }}"
+          class="button toggle-compact"
+          role="switch"
+          aria-checked="{{ 'true' if is_compact else 'false' }}"
+        >
+          {% if is_compact %}Standard layout{% else %}Compact layout{% endif %}
+        </a>
       </nav>
     </header>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,8 +1,12 @@
 {% extends "base.html" %}
 {% block title %}Tickets · TicketTracker{% endblock %}
 {% block content %}
+{% set is_compact = compact_mode|default(false) %}
 <section class="panel">
   <form method="get" class="filter-form" data-filter-form>
+    {% if is_compact %}
+      <input type="hidden" name="compact" value="1" />
+    {% endif %}
     <div class="filter-toolbar">
       <details
         class="filter-collapsible"
@@ -88,7 +92,7 @@
     </div>
     <div class="actions">
       <button type="submit" class="button primary">Apply</button>
-      <a href="{{ url_for('tickets.list_tickets') }}" class="button">Reset</a>
+      <a href="{{ url_for('tickets.list_tickets') }}{% if is_compact %}?compact=1{% endif %}" class="button">Reset</a>
     </div>
   </form>
 </section>
@@ -99,7 +103,11 @@
       <article class="ticket-card" style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};">
         <header>
           <div class="title-group">
-            <h2><a href="{{ url_for('tickets.ticket_detail', ticket_id=ticket.id) }}">{{ ticket.title }}</a></h2>
+            <h2>
+              <a href="{{ url_for('tickets.ticket_detail', ticket_id=ticket.id) }}{% if is_compact %}?compact=1{% endif %}">
+                {{ ticket.title }}
+              </a>
+            </h2>
             <div class="meta">
               <span class="status">{{ ticket.status }}{% if ticket.status == 'On Hold' and ticket.on_hold_reason %} · {{ ticket.on_hold_reason }}{% endif %}</span>
               {% set priority_color = config.colors.priorities.get(ticket.priority, '#3b82f6') %}
@@ -160,7 +168,10 @@
     {% endfor %}
   {% else %}
     <div class="empty-state">
-      <p>No tickets found. <a href="{{ url_for('tickets.create_ticket') }}">Create your first ticket.</a></p>
+      <p>
+        No tickets found.
+        <a href="{{ url_for('tickets.create_ticket') }}{% if is_compact %}?compact=1{% endif %}">Create your first ticket.</a>
+      </p>
     </div>
   {% endif %}
 </section>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ ticket.title }} · TicketTracker{% endblock %}
 {% block content %}
+{% set is_compact = compact_mode|default(false) %}
 <article class="ticket-detail" style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};">
   <header>
     <div class="title-group">
@@ -63,7 +64,12 @@
         {% endif %}
       </dl>
       <div class="actions">
-        <a class="button" href="{{ url_for('tickets.edit_ticket', ticket_id=ticket.id) }}">Edit ticket</a>
+        <a
+          class="button"
+          href="{{ url_for('tickets.edit_ticket', ticket_id=ticket.id) }}{% if is_compact %}?compact=1{% endif %}"
+        >
+          Edit ticket
+        </a>
       </div>
     </aside>
   </section>
@@ -85,7 +91,9 @@
       <ul>
         {% for attachment in ticket.attachments %}
           <li>
-            <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id) }}">{{ attachment.display_name }}</a>
+            <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id) }}{% if is_compact %}?compact=1{% endif %}">
+              {{ attachment.display_name }}
+            </a>
             <span class="attachment-meta">Uploaded {{ attachment.uploaded_at.strftime('%b %d, %Y %H:%M') }}</span>
           </li>
         {% endfor %}
@@ -113,7 +121,11 @@
             {% if update.attachments %}
               <ul class="update-attachments">
                 {% for attachment in update.attachments %}
-                  <li><a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id) }}">{{ attachment.display_name }}</a></li>
+                  <li>
+                    <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id) }}{% if is_compact %}?compact=1{% endif %}">
+                      {{ attachment.display_name }}
+                    </a>
+                  </li>
                 {% endfor %}
               </ul>
             {% endif %}
@@ -128,7 +140,12 @@
 
 <section class="panel">
   <h3>Add update</h3>
-  <form method="post" action="{{ url_for('tickets.add_update', ticket_id=ticket.id) }}" enctype="multipart/form-data" class="update-form">
+  <form
+    method="post"
+    action="{{ url_for('tickets.add_update', ticket_id=ticket.id) }}{% if is_compact %}?compact=1{% endif %}"
+    enctype="multipart/form-data"
+    class="update-form"
+  >
     <div class="field-group">
       <label for="message">Message</label>
       <textarea id="message" name="message" rows="4" placeholder="Share progress, blockers, or notes"></textarea>

--- a/templates/ticket_form.html
+++ b/templates/ticket_form.html
@@ -4,11 +4,20 @@
 {% else %}
   {% set page_title = 'New Ticket' %}
 {% endif %}
+{% set is_compact = compact_mode|default(false) %}
+{% if ticket %}
+  {% set form_action = url_for('tickets.edit_ticket', ticket_id=ticket.id) %}
+{% else %}
+  {% set form_action = url_for('tickets.create_ticket') %}
+{% endif %}
+{% if is_compact %}
+  {% set form_action = form_action ~ '?compact=1' %}
+{% endif %}
 {% block title %}{{ page_title }} · TicketTracker{% endblock %}
 {% block content %}
 <section class="panel">
   <h2>{{ page_title }}</h2>
-  <form method="post" enctype="multipart/form-data" class="ticket-form">
+  <form method="post" action="{{ form_action }}" enctype="multipart/form-data" class="ticket-form">
     <div class="field-group">
       <label for="title">Title</label>
       <input type="text" id="title" name="title" value="{{ ticket.title if ticket else '' }}" required />
@@ -77,7 +86,7 @@
     </div>
     <div class="actions">
       <button type="submit" class="button primary">Save</button>
-      <a class="button" href="{{ url_for('tickets.list_tickets') }}">Cancel</a>
+      <a class="button" href="{{ url_for('tickets.list_tickets') }}{% if is_compact %}?compact=1{% endif %}">Cancel</a>
     </div>
   </form>
 </section>


### PR DESCRIPTION
## Summary
- add a compact-mode switch in the layout header that keeps existing filters and parameters intact
- propagate the compact flag through ticket list, detail, and form views so navigation stays in the chosen mode
- tighten spacing, padding, and typography under the new compact class to deliver a denser layout while remaining legible

## Testing
- pytest
- python -m compileall tickettracker

------
https://chatgpt.com/codex/tasks/task_e_68f925198dfc832c8d6368fa09582b37