### PR TITLE
Add ticket age reference date tracking and re-age workflow

### DIFF
--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -22,6 +22,9 @@
           <span class="due">Due {{ ticket.due_date.strftime('%b %d, %Y %H:%M') }}</span>
         {% else %}
           <span class="due no-date">No due date</span>
+          {% if ticket.age_reference_date %}
+            <span class="age-reference">Aging since {{ ticket.age_reference_date.strftime('%b %d, %Y') }}</span>
+          {% endif %}
         {% endif %}
       </div>
     </div>
@@ -180,6 +183,12 @@
     </div>
     <div class="actions">
       <button type="submit" class="button primary">Add update</button>
+      {% if not ticket.due_date %}
+        <label class="checkbox" for="reage_ticket">
+          <input type="checkbox" id="reage_ticket" name="reage_ticket" value="1" />
+          Re-age ticket
+        </label>
+      {% endif %}
     </div>
   </form>
 </section>

--- a/tickettracker/app.py
+++ b/tickettracker/app.py
@@ -8,6 +8,7 @@ from flask import Flask
 
 from .config import AppConfig, load_config
 from .extensions import db
+from .migrations import run_migrations
 
 
 def create_app(config_path: Optional[str | Path] = None) -> Flask:
@@ -40,6 +41,7 @@ def create_app(config_path: Optional[str | Path] = None) -> Flask:
         from . import models  # noqa: F401
 
         db.create_all()
+        run_migrations()
 
     from .views.tickets import tickets_bp
 

--- a/tickettracker/migrations.py
+++ b/tickettracker/migrations.py
@@ -1,0 +1,32 @@
+"""Lightweight schema migration utilities for TicketTracker."""
+from __future__ import annotations
+
+from sqlalchemy import inspect, text
+
+from .extensions import db
+
+
+def run_migrations() -> None:
+    """Apply idempotent schema migrations required by the application."""
+
+    engine = db.engine
+    inspector = inspect(engine)
+    if "tickets" not in inspector.get_table_names():
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("tickets")}
+    if "age_reference_date" in columns:
+        return
+
+    with engine.begin() as connection:
+        connection.execute(
+            text("ALTER TABLE tickets ADD COLUMN age_reference_date DATE")
+        )
+        connection.execute(
+            text(
+                "UPDATE tickets "
+                "SET age_reference_date = DATE(created_at) "
+                "WHERE age_reference_date IS NULL"
+            )
+        )
+

--- a/tickettracker/models.py
+++ b/tickettracker/models.py
@@ -1,7 +1,7 @@
 """Database models for TicketTracker."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Iterable, List, Sequence
 
 from sqlalchemy import event
@@ -39,6 +39,11 @@ class Ticket(db.Model):
     created_at: Mapped[datetime] = mapped_column(db.DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+    age_reference_date: Mapped[date | None] = mapped_column(
+        db.Date,
+        nullable=True,
+        default=lambda: datetime.utcnow().date(),
     )
 
     updates: Mapped[List["TicketUpdate"]] = relationship(


### PR DESCRIPTION
## Summary
- add a nullable `age_reference_date` to tickets with a lightweight migration to backfill existing records
- update SLA priority threshold parsing and ticket color logic to use the reference date when no due date is set
- expose re-age controls on the ticket detail page and reset the reference date when requested, displaying the current reference date for transparency

## Testing
- pytest
- python -m compileall tickettracker templates

------
https://chatgpt.com/codex/tasks/task_e_68f9286679ec832cb765450f2ce94425