### PR TITLE
Enhance overdue ticket highlighting

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -570,6 +570,16 @@ body.compact .app-footer {
   pointer-events: none;
 }
 
+.ticket-card[data-overdue='true'] {
+  --ticket-glow: color-mix(in srgb, var(--ticket-accent, var(--accent)) 70%, transparent);
+  box-shadow: 0 0 0 2px var(--ticket-glow), 0 0 34px var(--ticket-glow);
+}
+
+.ticket-card[data-overdue='true']::before {
+  border-width: 4px;
+  opacity: 0.7;
+}
+
 .ticket-card header,
 .ticket-detail > header {
   display: flex;
@@ -708,6 +718,16 @@ body.compact .app-footer {
   border: 3px solid var(--ticket-accent, rgba(56, 189, 248, 0.6));
   opacity: 0.2;
   pointer-events: none;
+}
+
+.ticket-detail[data-overdue='true'] {
+  --ticket-glow: color-mix(in srgb, var(--ticket-accent, rgba(56, 189, 248, 0.8)) 70%, transparent);
+  box-shadow: 0 0 0 3px var(--ticket-glow), 0 0 48px var(--ticket-glow);
+}
+
+.ticket-detail[data-overdue='true']::before {
+  border-width: 5px;
+  opacity: 0.55;
 }
 
 .detail-grid {

--- a/templates/index.html
+++ b/templates/index.html
@@ -100,7 +100,11 @@
 <section class="ticket-grid">
   {% if tickets %}
     {% for ticket in tickets %}
-      <article class="ticket-card" style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};">
+      <article
+        class="ticket-card{% if ticket.is_overdue %} is-overdue{% endif %}"
+        data-overdue="{{ 'true' if ticket.is_overdue else 'false' }}"
+        style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};"
+      >
         <header>
           <div class="title-group">
             <h2>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -2,7 +2,11 @@
 {% block title %}{{ ticket.title }} · TicketTracker{% endblock %}
 {% block content %}
 {% set is_compact = compact_mode|default(false) %}
-<article class="ticket-detail" style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};">
+<article
+  class="ticket-detail{% if ticket.is_overdue %} is-overdue{% endif %}"
+  data-overdue="{{ 'true' if ticket.is_overdue else 'false' }}"
+  style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};"
+>
   <header>
     <div class="title-group">
       <h2>{{ ticket.title }}</h2>


### PR DESCRIPTION
## Summary
- boost tint intensities to 50% opacity, add overdue saturation handling, and mark tickets with an overdue flag for styling
- expose the overdue state in list/detail templates so the UI can react to runtime styling cues
- amplify overdue card and detail styling with stronger borders and glow effects while keeping fills capped at 50%

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9310adca8832ca96b8d64e3fad7dc