### PR TITLE
Add SLA countdown chips for backlog tickets

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,7 +21,8 @@
       "Medium": [10, 15, 20, 25],
       "High": [5, 7, 10, 14],
       "Critical": [2, 3, 5, 7]
-    }
+    },
+    "default_due_days": 21
   },
   "colors": {
     "gradient": {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -630,6 +630,42 @@ body.compact .app-footer {
   box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.45), 0 12px 28px rgba(2, 6, 23, 0.45);
 }
 
+.due.sla-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  background: rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: var(--text);
+  box-shadow: 0 6px 18px rgba(2, 6, 23, 0.35);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.due.sla-chip[data-sla-breached='false'] {
+  background: color-mix(in srgb, var(--ticket-accent, var(--accent)) 22%, transparent);
+  border-color: color-mix(
+    in srgb,
+    var(--ticket-accent, var(--accent)) 55%,
+    transparent
+  );
+  color: color-mix(in srgb, var(--ticket-accent, var(--accent)) 80%, #f8fafc 40%);
+}
+
+.due.sla-chip[data-sla-breached='true'] {
+  background: color-mix(in srgb, var(--danger) 32%, transparent);
+  border-color: color-mix(in srgb, var(--danger) 55%, transparent);
+  color: color-mix(in srgb, var(--danger) 80%, #fee2e2 35%);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--danger) 45%, transparent),
+    0 10px 24px rgba(127, 29, 29, 0.45);
+}
+
 .ticket-card .timestamps,
 .ticket-detail .timestamps {
   display: flex;

--- a/templates/index.html
+++ b/templates/index.html
@@ -126,6 +126,13 @@
               </span>
               {% if ticket.due_date %}
                 <span class="due">Due {{ ticket.due_date.strftime('%b %d, %Y %H:%M') }}</span>
+              {% elif ticket.sla_countdown %}
+                <span
+                  class="due sla-chip"
+                  data-sla-breached="{{ 'true' if ticket.sla_is_breached else 'false' }}"
+                >
+                  {{ ticket.sla_countdown }}
+                </span>
               {% else %}
                 <span class="due no-date">No due date</span>
               {% endif %}

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -24,6 +24,16 @@
         </span>
         {% if ticket.due_date %}
           <span class="due">Due {{ ticket.due_date.strftime('%b %d, %Y %H:%M') }}</span>
+        {% elif ticket.sla_countdown %}
+          <span
+            class="due sla-chip"
+            data-sla-breached="{{ 'true' if ticket.sla_is_breached else 'false' }}"
+          >
+            {{ ticket.sla_countdown }}
+          </span>
+          {% if ticket.age_reference_date %}
+            <span class="age-reference">Aging since {{ ticket.age_reference_date.strftime('%b %d, %Y') }}</span>
+          {% endif %}
         {% else %}
           <span class="due no-date">No due date</span>
           {% if ticket.age_reference_date %}


### PR DESCRIPTION
## Summary
- extend the SLA configuration with a default due window and helper for remaining days
- annotate tickets without due dates with SLA countdown metadata and expose the formatted chip in the UI
- style the SLA countdown indicator to match the existing visual language

## Testing
- `pytest`
- `python -m compileall tickettracker`
- `python -m pip install --quiet flake8` *(fails: proxy 403 while downloading)*

------
https://chatgpt.com/codex/tasks/task_e_68f9334e8178832c9b0d3d1b63b75d65