### PR TITLE
Add tooltips for compact ticket cards

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -104,6 +104,10 @@
         class="ticket-card{% if ticket.is_overdue %} is-overdue{% endif %}"
         data-overdue="{{ 'true' if ticket.is_overdue else 'false' }}"
         style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};"
+        {% if is_compact and ticket.compact_tooltip %}
+          title="{{ ticket.compact_tooltip }}"
+          aria-label="{{ ticket.compact_tooltip }}"
+        {% endif %}
       >
         <header>
           <div class="title-group">
@@ -155,26 +159,28 @@
           </div>
         </header>
         <p class="description">{{ ticket.description|truncate(240) }}</p>
-        <dl class="ticket-details">
-          {% if ticket.requester %}
-            <div>
-              <dt>Requester</dt>
-              <dd>{{ ticket.requester }}</dd>
-            </div>
-          {% endif %}
-          {% if ticket.watchers %}
-            <div>
-              <dt>Watchers</dt>
-              <dd>{{ ticket.watchers|join(', ') }}</dd>
-            </div>
-          {% endif %}
-          {% if ticket.links %}
-            <div>
-              <dt>Links</dt>
-              <dd>{{ ticket.links }}</dd>
-            </div>
-          {% endif %}
-        </dl>
+        {% if not is_compact and (ticket.requester or ticket.watchers or ticket.links) %}
+          <dl class="ticket-details">
+            {% if ticket.requester %}
+              <div>
+                <dt>Requester</dt>
+                <dd>{{ ticket.requester }}</dd>
+              </div>
+            {% endif %}
+            {% if ticket.watchers %}
+              <div>
+                <dt>Watchers</dt>
+                <dd>{{ ticket.watchers|join(', ') }}</dd>
+              </div>
+            {% endif %}
+            {% if ticket.links %}
+              <div>
+                <dt>Links</dt>
+                <dd>{{ ticket.links }}</dd>
+              </div>
+            {% endif %}
+          </dl>
+        {% endif %}
         {% if ticket.tags %}
           <ul class="tags">
             {% for tag in ticket.tags %}

--- a/tickettracker/views/tickets.py
+++ b/tickettracker/views/tickets.py
@@ -258,6 +258,27 @@ def _annotate_due_state(ticket: Ticket, config: AppConfig) -> None:
     ticket.due_badge_color = badge_color  # type: ignore[attr-defined]
 
 
+def _compose_compact_tooltip(ticket: Ticket) -> str | None:
+    """Return a tooltip summarizing requester, watchers, and links."""
+
+    details: List[str] = []
+
+    if ticket.requester:
+        details.append(f"Requester: {ticket.requester}")
+
+    watchers = ticket.watchers
+    if watchers:
+        details.append(f"Watchers: {', '.join(watchers)}")
+
+    if ticket.links:
+        details.append(f"Links: {ticket.links}")
+
+    if not details:
+        return None
+
+    return " • ".join(details)
+
+
 def _boost_overdue_rgb(red: int, green: int, blue: int) -> tuple[int, int, int]:
     """Return an intensified RGB tuple for overdue overlays."""
 
@@ -449,6 +470,7 @@ def list_tickets():
         )  # type: ignore[attr-defined]
         _annotate_ticket_sla(ticket, config, now)
         _annotate_due_state(ticket, config)
+        ticket.compact_tooltip = _compose_compact_tooltip(ticket)  # type: ignore[attr-defined]
 
     available_tags = Tag.query.order_by(Tag.name).all()
 


### PR DESCRIPTION
## Summary
- hide the requester, watchers, and links block in the compact ticket grid
- generate tooltip metadata so compact cards expose requester/watchers/link details

## Testing
- pytest
- python -m compileall tickettracker

------
https://chatgpt.com/codex/tasks/task_e_68f938cfe718832c9893da1d3bc48a8b