### PR TITLE
Ensure compact mode defaults and query persistence

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,8 @@
       rel="stylesheet"
     />
   </head>
-  {% set is_compact = compact_mode|default(false) %}
+  {% set is_compact = compact_mode|default(true) %}
+  {% set compact_value = '1' if is_compact else '0' %}
   <body class="{% if is_compact %}compact{% endif %}">
     <header class="app-header">
       <div class="brand">
@@ -23,9 +24,9 @@
         </div>
       </div>
       <nav class="nav-links">
-        <a href="{{ url_for('tickets.list_tickets', compact='1') if is_compact else url_for('tickets.list_tickets') }}">Tickets</a>
+        <a href="{{ url_for('tickets.list_tickets', compact=compact_value) }}">Tickets</a>
         <a
-          href="{{ url_for('tickets.create_ticket', compact='1') if is_compact else url_for('tickets.create_ticket') }}"
+          href="{{ url_for('tickets.create_ticket', compact=compact_value) }}"
           class="button primary"
         >
           New Ticket

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,12 +1,11 @@
 {% extends "base.html" %}
 {% block title %}Tickets · TicketTracker{% endblock %}
 {% block content %}
-{% set is_compact = compact_mode|default(false) %}
+{% set is_compact = compact_mode|default(true) %}
+{% set compact_value = '1' if is_compact else '0' %}
 <section class="panel">
   <form method="get" class="filter-form" data-filter-form>
-    {% if is_compact %}
-      <input type="hidden" name="compact" value="1" />
-    {% endif %}
+    <input type="hidden" name="compact" value="{{ compact_value }}" />
     <div class="filter-toolbar">
       <details
         class="filter-collapsible"
@@ -92,7 +91,7 @@
     </div>
     <div class="actions">
       <button type="submit" class="button primary">Apply</button>
-      <a href="{{ url_for('tickets.list_tickets') }}{% if is_compact %}?compact=1{% endif %}" class="button">Reset</a>
+      <a href="{{ url_for('tickets.list_tickets', compact=compact_value) }}" class="button">Reset</a>
     </div>
   </form>
 </section>
@@ -112,7 +111,7 @@
         <header>
           <div class="title-group">
             <h2>
-              <a href="{{ url_for('tickets.ticket_detail', ticket_id=ticket.id) }}{% if is_compact %}?compact=1{% endif %}">
+              <a href="{{ url_for('tickets.ticket_detail', ticket_id=ticket.id, compact=compact_value) }}">
                 {{ ticket.title }}
               </a>
             </h2>
@@ -198,7 +197,7 @@
     <div class="empty-state">
       <p>
         No tickets found.
-        <a href="{{ url_for('tickets.create_ticket') }}{% if is_compact %}?compact=1{% endif %}">Create your first ticket.</a>
+        <a href="{{ url_for('tickets.create_ticket', compact=compact_value) }}">Create your first ticket.</a>
       </p>
     </div>
   {% endif %}

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% block title %}{{ ticket.title }} · TicketTracker{% endblock %}
 {% block content %}
-{% set is_compact = compact_mode|default(false) %}
+{% set is_compact = compact_mode|default(true) %}
+{% set compact_value = '1' if is_compact else '0' %}
 <article
   class="ticket-detail{% if ticket.is_overdue %} is-overdue{% endif %}"
   data-overdue="{{ 'true' if ticket.is_overdue else 'false' }}"
@@ -88,7 +89,7 @@
       <div class="actions">
         <a
           class="button"
-          href="{{ url_for('tickets.edit_ticket', ticket_id=ticket.id) }}{% if is_compact %}?compact=1{% endif %}"
+          href="{{ url_for('tickets.edit_ticket', ticket_id=ticket.id, compact=compact_value) }}"
         >
           Edit ticket
         </a>
@@ -113,7 +114,7 @@
       <ul>
         {% for attachment in ticket.attachments %}
           <li>
-            <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id) }}{% if is_compact %}?compact=1{% endif %}">
+            <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id, compact=compact_value) }}">
               {{ attachment.display_name }}
             </a>
             <span class="attachment-meta">Uploaded {{ attachment.uploaded_at.strftime('%b %d, %Y %H:%M') }}</span>
@@ -144,7 +145,7 @@
               <ul class="update-attachments">
                 {% for attachment in update.attachments %}
                   <li>
-                    <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id) }}{% if is_compact %}?compact=1{% endif %}">
+                    <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id, compact=compact_value) }}">
                       {{ attachment.display_name }}
                     </a>
                   </li>
@@ -164,7 +165,7 @@
   <h3>Add update</h3>
   <form
     method="post"
-    action="{{ url_for('tickets.add_update', ticket_id=ticket.id) }}{% if is_compact %}?compact=1{% endif %}"
+    action="{{ url_for('tickets.add_update', ticket_id=ticket.id, compact=compact_value) }}"
     enctype="multipart/form-data"
     class="update-form"
   >

--- a/templates/ticket_form.html
+++ b/templates/ticket_form.html
@@ -4,14 +4,12 @@
 {% else %}
   {% set page_title = 'New Ticket' %}
 {% endif %}
-{% set is_compact = compact_mode|default(false) %}
+{% set is_compact = compact_mode|default(true) %}
+{% set compact_value = '1' if is_compact else '0' %}
 {% if ticket %}
-  {% set form_action = url_for('tickets.edit_ticket', ticket_id=ticket.id) %}
+  {% set form_action = url_for('tickets.edit_ticket', ticket_id=ticket.id, compact=compact_value) %}
 {% else %}
-  {% set form_action = url_for('tickets.create_ticket') %}
-{% endif %}
-{% if is_compact %}
-  {% set form_action = form_action ~ '?compact=1' %}
+  {% set form_action = url_for('tickets.create_ticket', compact=compact_value) %}
 {% endif %}
 {% block title %}{{ page_title }} · TicketTracker{% endblock %}
 {% block content %}
@@ -86,7 +84,7 @@
     </div>
     <div class="actions">
       <button type="submit" class="button primary">Save</button>
-      <a class="button" href="{{ url_for('tickets.list_tickets') }}{% if is_compact %}?compact=1{% endif %}">Cancel</a>
+      <a class="button" href="{{ url_for('tickets.list_tickets', compact=compact_value) }}">Cancel</a>
     </div>
   </form>
 </section>

--- a/tickettracker/views/tickets.py
+++ b/tickettracker/views/tickets.py
@@ -316,18 +316,26 @@ def _is_compact_mode() -> bool:
 
     value = request.args.get("compact")
     if value is None:
+        return True
+
+    normalized = value.strip().lower()
+    if normalized in {"0", "false", "no", "off"}:
         return False
-    return value.lower() in {"1", "true", "yes", "on"}
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    return True
+
+
+def _compact_query_value(compact_mode: bool) -> str:
+    return "1" if compact_mode else "0"
 
 
 def _build_compact_toggle_url(endpoint: str, compact_mode: bool, **values: object) -> str:
     """Return a URL that toggles the compact flag while preserving filters."""
 
     query_args: Dict[str, List[str]] = {key: list(items) for key, items in request.args.lists()}
-    if compact_mode:
-        query_args.pop("compact", None)
-    else:
-        query_args["compact"] = ["1"]
+    toggled_value = _compact_query_value(not compact_mode)
+    query_args["compact"] = [toggled_value]
 
     flattened: Dict[str, object] = {
         key: value if len(value) != 1 else value[0]
@@ -567,7 +575,7 @@ def create_ticket():
             url_for(
                 "tickets.ticket_detail",
                 ticket_id=ticket.id,
-                **({"compact": "1"} if compact_mode else {}),
+                compact=_compact_query_value(compact_mode),
             )
         )
 
@@ -625,7 +633,7 @@ def edit_ticket(ticket_id: int):
             url_for(
                 "tickets.ticket_detail",
                 ticket_id=ticket.id,
-                **({"compact": "1"} if compact_mode else {}),
+                compact=_compact_query_value(compact_mode),
             )
         )
 
@@ -682,7 +690,7 @@ def add_update(ticket_id: int):
         url_for(
             "tickets.ticket_detail",
             ticket_id=ticket.id,
-            **({"compact": "1"} if compact_mode else {}),
+            compact=_compact_query_value(compact_mode),
         )
     )
 
@@ -699,7 +707,7 @@ def download_attachment(attachment_id: int):
             url_for(
                 "tickets.ticket_detail",
                 ticket_id=attachment.ticket_id,
-                **({"compact": "1"} if compact_mode else {}),
+                compact=_compact_query_value(compact_mode),
             )
         )
 


### PR DESCRIPTION
## Summary
- default the compact layout flag to true while respecting explicit false requests
- toggle URLs and redirects now carry compact=1/0 so the mode persists between views
- update navigation, ticket list, and form templates to include the current compact query value in all links and submissions

## Testing
- pytest
- python -m compileall tickettracker
- flake8 *(fails: installation blocked by proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68f939bab2a0832c9d5e7eead6fc9f15