### PR TITLE
Add icon-forward header navigation controls

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -92,20 +92,96 @@ a:hover {
   font-weight: 500;
 }
 
-.nav-links .button.primary {
-  padding: 0.5rem 1.25rem;
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.85rem;
+  height: 2.85rem;
+  border-radius: 0.85rem;
+  padding: 0;
+  position: relative;
+  line-height: 1;
+  transition: border 0.2s ease, background 0.2s ease, color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.icon-button .icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+}
+
+.icon-button .icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: currentColor;
+}
+
+.icon-button:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.65);
+  outline-offset: 3px;
+}
+
+.button.icon-button {
+  padding: 0;
+}
+
+.nav-links a.icon-button:not(.button) {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--text-muted);
+}
+
+.nav-links a.icon-button:not(.button):hover,
+.nav-links a.icon-button:not(.button):focus-visible {
+  color: #f8fafc;
+  border-color: rgba(56, 189, 248, 0.6);
+  background: rgba(56, 189, 248, 0.2);
+  text-decoration: none;
+  box-shadow: 0 12px 32px rgba(2, 6, 23, 0.35);
+}
+
+.nav-links .button.icon-button {
+  width: 2.85rem;
+  height: 2.85rem;
+}
+
+.nav-links .button.icon-button .icon {
+  font-size: 1.3rem;
+}
+
+.nav-links .button.icon-button:hover,
+.nav-links .button.icon-button:focus-visible {
+  text-decoration: none;
+  box-shadow: 0 14px 32px rgba(2, 6, 23, 0.45);
+}
+
+.nav-links .toggle-compact {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--text-muted);
+}
+
+.nav-links .toggle-compact:hover,
+.nav-links .toggle-compact:focus-visible {
+  color: #f8fafc;
+  border-color: rgba(56, 189, 248, 0.7);
+  background: rgba(56, 189, 248, 0.28);
+}
+
+.toggle-compact[aria-checked='true'] {
+  color: #f8fafc;
+  border-color: rgba(56, 189, 248, 0.8);
+  background: rgba(56, 189, 248, 0.35);
+  box-shadow: 0 14px 36px rgba(2, 6, 23, 0.5);
 }
 
 .content {
   width: min(1100px, 92vw);
   margin: 2rem auto 4rem;
   flex: 1;
-}
-
-.nav-links .toggle-compact {
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
 /* Compact mode adjustments */
@@ -125,17 +201,24 @@ body.compact .nav-links {
   gap: 0.75rem;
 }
 
+body.compact .icon-button {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+body.compact .nav-links .button.icon-button {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+}
+
 body.compact .button {
   padding: 0.5rem 1rem;
   border-radius: 0.65rem;
 }
 
-body.compact .nav-links .button {
+body.compact .nav-links .button:not(.icon-button) {
   padding: 0.45rem 0.95rem;
-}
-
-body.compact .nav-links .button.primary {
-  padding: 0.45rem 1.05rem;
 }
 
 body.compact .content {

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,21 +23,57 @@
           <p class="subtitle">Local-first ticketing desk</p>
         </div>
       </div>
+      {% set toggle_label = 'Switch to standard layout (currently compact)' if is_compact else 'Switch to compact layout (currently standard)' %}
       <nav class="nav-links">
-        <a href="{{ url_for('tickets.list_tickets', compact=compact_value) }}">Tickets</a>
+        <a
+          href="{{ url_for('tickets.list_tickets', compact=compact_value) }}"
+          class="icon-button"
+          aria-label="View tickets"
+          title="View tickets"
+        >
+          <span class="icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+              <rect x="5" y="6" width="14" height="3" rx="1.5"></rect>
+              <rect x="5" y="11" width="14" height="3" rx="1.5"></rect>
+              <rect x="5" y="16" width="14" height="3" rx="1.5"></rect>
+            </svg>
+          </span>
+          <span class="sr-only">View tickets</span>
+        </a>
         <a
           href="{{ url_for('tickets.create_ticket', compact=compact_value) }}"
-          class="button primary"
+          class="button primary icon-button"
+          aria-label="Create a new ticket"
+          title="Create a new ticket"
         >
-          New Ticket
+          <span class="icon" aria-hidden="true">＋</span>
+          <span class="sr-only">Create a new ticket</span>
         </a>
         <a
           href="{{ compact_toggle_url|default(request.url) }}"
-          class="button toggle-compact"
+          class="button icon-button toggle-compact"
           role="switch"
           aria-checked="{{ 'true' if is_compact else 'false' }}"
+          aria-label="{{ toggle_label }}"
+          title="{{ toggle_label }}"
         >
-          {% if is_compact %}Standard layout{% else %}Compact layout{% endif %}
+          <span class="icon" aria-hidden="true">
+            {% if is_compact %}
+              <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                <rect x="4" y="5" width="16" height="4" rx="1.5"></rect>
+                <rect x="4" y="11" width="16" height="4" rx="1.5"></rect>
+                <rect x="4" y="17" width="16" height="2" rx="1"></rect>
+              </svg>
+            {% else %}
+              <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                <rect x="4" y="5" width="7" height="7" rx="1.5"></rect>
+                <rect x="13" y="5" width="7" height="7" rx="1.5"></rect>
+                <rect x="4" y="14" width="7" height="7" rx="1.5"></rect>
+                <rect x="13" y="14" width="7" height="7" rx="1.5"></rect>
+              </svg>
+            {% endif %}
+          </span>
+          <span class="sr-only">{{ toggle_label }}</span>
         </a>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- replace the header navigation text links with icon-based controls that keep accessible labels
- add icon-button styling, focus states, and layout toggle state treatments for standard and compact views

## Testing
- pytest
- flake8 *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f93be2dd88832c93957600ee515e35