### PR TITLE
Hide empty attachments section on ticket detail view

### DIFF
--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -108,9 +108,9 @@
     </section>
   {% endif %}
 
-  <section class="attachments">
-    <h3>Attachments</h3>
-    {% if ticket.attachments %}
+  {% if ticket.attachments %}
+    <section class="attachments">
+      <h3>Attachments</h3>
       <ul>
         {% for attachment in ticket.attachments %}
           <li>
@@ -121,10 +121,8 @@
           </li>
         {% endfor %}
       </ul>
-    {% else %}
-      <p class="empty">No attachments yet.</p>
-    {% endif %}
-  </section>
+    </section>
+  {% endif %}
 
   <section class="updates">
     <h3>Updates</h3>


### PR DESCRIPTION
## Summary
- wrap the ticket-level attachments section in the detail template with a conditional so it only renders when attachments exist

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f94101d4a0832cbe9dc3ad8e7ba94e