### PR TITLE
Add configurable submitted-by default for ticket updates

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
   "uploads": {
     "directory": "uploads"
   },
+  "default_submitted_by": "Support Team",
   "priorities": ["Low", "Medium", "High", "Critical"],
   "hold_reasons": [
     "Awaiting customer response",

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -132,7 +132,10 @@
           <div class="timeline-point"></div>
           <div class="timeline-content">
             <div class="update-meta">
-              <span class="author">{{ update.author or 'System' }}</span>
+              <span class="author">
+                Submitted By:
+                {{ 'System' if update.is_system else (update.author or config.default_submitted_by) }}
+              </span>
               <span class="timestamp">{{ update.created_at.strftime('%b %d, %Y %H:%M') }}</span>
               {% if update.status_from or update.status_to %}
                 <span class="status-change">{{ update.status_from or '—' }} → {{ update.status_to or '—' }}</span>
@@ -173,8 +176,14 @@
     </div>
     <div class="field-group split">
       <div>
-        <label for="author">Author</label>
-        <input type="text" id="author" name="author" placeholder="Optional" />
+        <label for="submitted_by">Submitted By</label>
+        <input
+          type="text"
+          id="submitted_by"
+          name="submitted_by"
+          placeholder="Submitted By (defaults to {{ config.default_submitted_by }})"
+          value="{{ config.default_submitted_by }}"
+        />
       </div>
       <div>
         <label for="status">Status</label>

--- a/tickettracker/config.py
+++ b/tickettracker/config.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
 DEFAULT_CONFIG_NAME = "config.json"
 
 DEFAULT_SECRET_KEY = "dev-secret-key-change-me"
+DEFAULT_SUBMITTED_BY = "Support Team"
 
 
 GRADIENT_STAGE_ORDER: List[str] = ["stage0", "stage1", "stage2", "stage3"]
@@ -38,6 +39,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "secret_key": DEFAULT_SECRET_KEY,
     "database": {"uri": "sqlite:///tickettracker.db"},
     "uploads": {"directory": "uploads"},
+    "default_submitted_by": DEFAULT_SUBMITTED_BY,
     "priorities": ["Low", "Medium", "High", "Critical"],
     "hold_reasons": [
         "Awaiting customer response",
@@ -155,6 +157,7 @@ class AppConfig:
     priorities: List[str]
     hold_reasons: List[str]
     workflow: List[str]
+    default_submitted_by: str
     sla: SLAConfig
     colors: ColorConfig
 
@@ -289,6 +292,20 @@ def load_config(config_path: Optional[os.PathLike[str] | str] = None) -> AppConf
     merged: Dict[str, Any] = json.loads(json.dumps(DEFAULT_CONFIG))  # deep copy
     _merge_dict(merged, loaded_data)
 
+    default_submitted_by_value = merged.get(
+        "default_submitted_by", DEFAULT_SUBMITTED_BY
+    )
+    if isinstance(default_submitted_by_value, str):
+        default_submitted_by = (
+            default_submitted_by_value.strip() or DEFAULT_SUBMITTED_BY
+        )
+    elif default_submitted_by_value is None:
+        default_submitted_by = DEFAULT_SUBMITTED_BY
+    else:
+        default_submitted_by = (
+            str(default_submitted_by_value).strip() or DEFAULT_SUBMITTED_BY
+        )
+
     sla_config = merged.get("sla", {})
     colors_config = merged.get("colors", {})
 
@@ -343,6 +360,7 @@ def load_config(config_path: Optional[os.PathLike[str] | str] = None) -> AppConf
         priorities=list(merged.get("priorities", [])),
         hold_reasons=list(merged.get("hold_reasons", [])),
         workflow=list(merged.get("workflow", [])),
+        default_submitted_by=default_submitted_by,
         sla=SLAConfig(
             due_stage_days=due_stage_days,
             priority_stage_days=priority_stage_days,

--- a/tickettracker/views/tickets.py
+++ b/tickettracker/views/tickets.py
@@ -654,10 +654,12 @@ def edit_ticket(ticket_id: int):
 @tickets_bp.route("/tickets/<int:ticket_id>/updates", methods=["POST"])
 def add_update(ticket_id: int):
     ticket = Ticket.query.get_or_404(ticket_id)
+    config = _app_config()
     compact_mode = _is_compact_mode()
 
     message = request.form.get("message", "").strip()
-    author = request.form.get("author") or None
+    submitted_by = (request.form.get("submitted_by") or "").strip()
+    author = submitted_by or config.default_submitted_by
     new_status = request.form.get("status") or ticket.status
     hold_reason = request.form.get("on_hold_reason") or None
     raw_re_age = request.form.get("reage_ticket")


### PR DESCRIPTION
## Summary
- add `default_submitted_by` to the application configuration and default JSON
- populate ticket update submissions with the configured default when no name is provided
- refresh the ticket detail form and timeline to use the "Submitted By" wording and default value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f941c1a6d4832caa7d9256aa142df9