### PR TITLE
Add configuration-driven ticket title color

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,6 +26,7 @@
     "default_due_days": 21
   },
   "colors": {
+    "ticket_title": "#f8fafc",
     "gradient": {
       "stage0": "#bae6fd",
       "stage1": "#fde047",

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -9,6 +9,7 @@
   --accent: #38bdf8;
   --accent-muted: rgba(56, 189, 248, 0.2);
   --danger: #f87171;
+  --ticket-title-color: #f8fafc;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
@@ -686,6 +687,28 @@ body.compact .app-footer {
 
 .ticket-card .title-group h2 {
   margin-bottom: 0.35rem;
+}
+
+.ticket-title {
+  color: var(--ticket-title-color, #f8fafc);
+}
+
+.ticket-title-link {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease, text-shadow 0.2s ease;
+}
+
+.ticket-title-link:hover,
+.ticket-title-link:focus-visible {
+  color: color-mix(in srgb, var(--ticket-title-color, #f8fafc) 90%, #ffffff 10%);
+  text-decoration: none;
+  text-shadow: 0 10px 32px rgba(15, 23, 42, 0.45);
+}
+
+.ticket-title-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ticket-title-color, #f8fafc) 65%, transparent 35%);
+  outline-offset: 4px;
 }
 
 .ticket-card .meta,

--- a/templates/index.html
+++ b/templates/index.html
@@ -96,7 +96,7 @@
   </form>
 </section>
 
-<section class="ticket-grid">
+<section class="ticket-grid" style="--ticket-title-color: {{ ticket_title_color|default('#f8fafc') }};">
   {% if tickets %}
     {% for ticket in tickets %}
       <article
@@ -110,8 +110,11 @@
       >
         <header>
           <div class="title-group">
-            <h2>
-              <a href="{{ url_for('tickets.ticket_detail', ticket_id=ticket.id, compact=compact_value) }}">
+            <h2 class="ticket-title">
+              <a
+                class="ticket-title-link"
+                href="{{ url_for('tickets.ticket_detail', ticket_id=ticket.id, compact=compact_value) }}"
+              >
                 {{ ticket.title }}
               </a>
             </h2>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -6,11 +6,11 @@
 <article
   class="ticket-detail{% if ticket.is_overdue %} is-overdue{% endif %}"
   data-overdue="{{ 'true' if ticket.is_overdue else 'false' }}"
-  style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};"
+  style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }}; --ticket-title-color: {{ ticket_title_color|default('#f8fafc') }};"
 >
   <header>
     <div class="title-group">
-      <h2>{{ ticket.title }}</h2>
+      <h2 class="ticket-title">{{ ticket.title }}</h2>
       <div class="meta">
         <span class="status">
           <span

--- a/tickettracker/config.py
+++ b/tickettracker/config.py
@@ -24,6 +24,8 @@ DEFAULT_GRADIENT_COLORS: Dict[str, str] = {
     GRADIENT_OVERDUE_KEY: "#7f1d1d",
 }
 
+DEFAULT_TICKET_TITLE_COLOR = "#f8fafc"
+
 DEFAULT_DUE_STAGE_DAYS: List[int] = [28, 21, 14, 7]
 DEFAULT_PRIORITY_STAGE_DAYS: Dict[str, List[int]] = {
     "Low": [14, 21, 28, 35],
@@ -54,6 +56,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "default_due_days": DEFAULT_BACKLOG_DUE_DAYS,
     },
     "colors": {
+        "ticket_title": DEFAULT_TICKET_TITLE_COLOR,
         "gradient": {
             **DEFAULT_GRADIENT_COLORS,
         },
@@ -132,6 +135,7 @@ class ColorConfig:
     statuses: Dict[str, str] = field(default_factory=dict)
     priorities: Dict[str, str] = field(default_factory=dict)
     tags: Dict[str, str] = field(default_factory=dict)
+    ticket_title: str = DEFAULT_TICKET_TITLE_COLOR
 
     def gradient_color(self, key: str) -> str:
         if key in DEFAULT_GRADIENT_COLORS:
@@ -145,6 +149,10 @@ class ColorConfig:
 
     def gradient_overdue_color(self) -> str:
         return self.gradient_color(GRADIENT_OVERDUE_KEY)
+
+    def ticket_title_color(self) -> str:
+        value = str(self.ticket_title or "").strip()
+        return value or DEFAULT_TICKET_TITLE_COLOR
 
 
 @dataclass
@@ -353,6 +361,14 @@ def load_config(config_path: Optional[os.PathLike[str] | str] = None) -> AppConf
     uploads_directory = _resolve_upload_directory(merged.get("uploads", {}).get("directory", "uploads"), base_path)
     secret_key = os.environ.get("TICKETTRACKER_SECRET_KEY") or str(merged.get("secret_key", DEFAULT_SECRET_KEY))
 
+    raw_ticket_title_color = colors_config.get("ticket_title", DEFAULT_TICKET_TITLE_COLOR)
+    if isinstance(raw_ticket_title_color, str):
+        ticket_title_color = raw_ticket_title_color.strip() or DEFAULT_TICKET_TITLE_COLOR
+    elif raw_ticket_title_color is None:
+        ticket_title_color = DEFAULT_TICKET_TITLE_COLOR
+    else:
+        ticket_title_color = str(raw_ticket_title_color).strip() or DEFAULT_TICKET_TITLE_COLOR
+
     return AppConfig(
         secret_key=secret_key,
         database_uri=database_uri,
@@ -371,5 +387,6 @@ def load_config(config_path: Optional[os.PathLike[str] | str] = None) -> AppConf
             statuses=dict(colors_config.get("statuses", {})),
             priorities=dict(colors_config.get("priorities", {})),
             tags=dict(colors_config.get("tags", {})),
+            ticket_title=ticket_title_color,
         ),
     )

--- a/tickettracker/views/tickets.py
+++ b/tickettracker/views/tickets.py
@@ -387,6 +387,7 @@ def list_tickets():
     query = Ticket.query
 
     compact_mode = _is_compact_mode()
+    title_color = config.colors.ticket_title_color()
 
     status_filter = request.args.get("status")
     if status_filter:
@@ -492,6 +493,7 @@ def list_tickets():
         compact_toggle_url=_build_compact_toggle_url(
             "tickets.list_tickets", compact_mode
         ),
+        ticket_title_color=title_color,
         filters={
             "status": status_filter,
             "priority": priority_filter,
@@ -516,6 +518,7 @@ def ticket_detail(ticket_id: int):
     config = _app_config()
     ticket = Ticket.query.get_or_404(ticket_id)
     compact_mode = _is_compact_mode()
+    title_color = config.colors.ticket_title_color()
     status_palette = _build_status_palette(config)
     ticket.display_color = _compute_ticket_color(ticket, config, status_palette)  # type: ignore[attr-defined]
     ticket.status_color = (
@@ -534,6 +537,7 @@ def ticket_detail(ticket_id: int):
         compact_toggle_url=_build_compact_toggle_url(
             "tickets.ticket_detail", compact_mode, ticket_id=ticket.id
         ),
+        ticket_title_color=title_color,
     )
 
 


### PR DESCRIPTION
## Summary
- add a configurable ticket title color to the default config and loader
- surface the resolved color in ticket views and templates
- update styles so ticket titles use the config-driven color consistently

## Testing
- python -m pytest
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68f944b6440c832cbacc5d329999e85b