### PR TITLE
Relocate filter actions into the collapsible filter block

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -493,6 +493,20 @@ body.compact .app-footer {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
+.filter-fields .filter-actions {
+  grid-column: 1 / -1;
+  justify-content: flex-end;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+body.compact .filter-fields .filter-actions {
+  gap: 0.6rem;
+  margin-top: 0.2rem;
+}
+
 .filter-indicator {
   color: var(--accent);
   font-size: 0.75rem;

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,6 +55,15 @@
               <label><input type="radio" name="tag_mode" value="all" {% if filters.tag_mode == 'all' %}checked{% endif %} /> All</label>
             </div>
           </div>
+          <div class="actions filter-actions" role="group" aria-label="Filter actions">
+            <button type="submit" class="button primary">Apply</button>
+            <a
+              href="{{ url_for('tickets.list_tickets', compact=compact_value) }}"
+              class="button"
+            >
+              Reset
+            </a>
+          </div>
         </div>
       </details>
       <div class="sort-controls" data-sort-controls>
@@ -88,10 +97,6 @@
         </div>
         <input type="hidden" name="order" value="{{ filters.order }}" data-sort-order />
       </div>
-    </div>
-    <div class="actions">
-      <button type="submit" class="button primary">Apply</button>
-      <a href="{{ url_for('tickets.list_tickets', compact=compact_value) }}" class="button">Reset</a>
     </div>
   </form>
 </section>


### PR DESCRIPTION
## Summary
- move the Apply and Reset controls inside the collapsible filter fieldset for better grouping
- adjust filter styles so the relocated actions remain aligned and responsive

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f947fcd0c0832caa56acc1d14c1436