### PR TITLE
Align filter toolbar markup and styling with sort controls

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -243,6 +243,10 @@ body.compact .filter-toolbar {
   gap: 1rem;
 }
 
+body.compact .filter-controls {
+  gap: 0.45rem;
+}
+
 body.compact .filter-collapsible {
   padding: 0.75rem 0.95rem;
   border-radius: 0.9rem;
@@ -452,8 +456,16 @@ body.compact .app-footer {
   justify-content: space-between;
 }
 
-.filter-collapsible {
+.filter-controls {
   flex: 1 1 360px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.6rem;
+}
+
+.filter-collapsible {
+  width: 100%;
   border: 1px solid rgba(148, 163, 184, 0.15);
   border-radius: 1rem;
   padding: 0.85rem 1.1rem;
@@ -468,7 +480,8 @@ body.compact .app-footer {
   gap: 0.5rem;
   cursor: pointer;
   font-weight: 600;
-  color: #f8fafc;
+  color: rgba(148, 163, 184, 0.85);
+  transition: color 0.2s ease;
 }
 
 .filter-collapsible > summary:focus-visible {
@@ -479,6 +492,29 @@ body.compact .app-footer {
 
 .filter-collapsible > summary::-webkit-details-marker {
   display: none;
+}
+
+.filter-collapsible[open] > summary,
+.filter-collapsible[data-has-active='true'] > summary {
+  color: #f8fafc;
+}
+
+.filter-toggle-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.filter-toggle-state--open {
+  display: none;
+}
+
+.filter-collapsible[open] .filter-toggle-state--closed {
+  display: none;
+}
+
+.filter-collapsible[open] .filter-toggle-state--open {
+  display: inline;
 }
 
 .filter-collapsible[open] {
@@ -532,6 +568,7 @@ body.compact .filter-fields .filter-actions {
   min-width: 220px;
 }
 
+.filter-label,
 .sort-label {
   font-size: 0.75rem;
   letter-spacing: 0.08em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,65 +7,71 @@
   <form method="get" class="filter-form" data-filter-form>
     <input type="hidden" name="compact" value="{{ compact_value }}" />
     <div class="filter-toolbar">
-      <details
-        class="filter-collapsible"
-        data-filter-collapsible
-        data-has-active="{{ 'true' if filters.has_active_filters else 'false' }}"
-        {% if filters.has_active_filters %}open{% endif %}
-      >
-        <summary class="filter-toggle">
-          <span>Filters</span>
-          {% if filters.has_active_filters %}
-            <span class="filter-indicator" aria-hidden="true">•</span>
-            <span class="sr-only">Active filters applied</span>
-          {% endif %}
-        </summary>
-        <div class="filter-fields">
-          <div class="field-group">
-            <label for="search">Search</label>
-            <input type="search" id="search" name="q" placeholder="Search tickets" value="{{ filters.search or '' }}" />
-          </div>
-          <div class="field-group">
-            <label for="status">Status</label>
-            <select id="status" name="status">
-              <option value="">All</option>
-              {% for status in config.workflow %}
-                <option value="{{ status }}" {% if filters.status == status %}selected{% endif %}>{{ status }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="field-group">
-            <label for="priority">Priority</label>
-            <select id="priority" name="priority">
-              <option value="">All</option>
-              {% for priority in priorities %}
-                <option value="{{ priority }}" {% if filters.priority == priority %}selected{% endif %}>{{ priority }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="field-group">
-            <label for="tag">Tags</label>
-            <select id="tag" name="tag" multiple size="3">
-              {% for tag in available_tags %}
-                <option value="{{ tag.name }}" {% if tag.name in filters.tags %}selected{% endif %}>{{ tag.name }}</option>
-              {% endfor %}
-            </select>
-            <div class="tag-mode">
-              <label><input type="radio" name="tag_mode" value="any" {% if filters.tag_mode != 'all' %}checked{% endif %} /> Any</label>
-              <label><input type="radio" name="tag_mode" value="all" {% if filters.tag_mode == 'all' %}checked{% endif %} /> All</label>
+      <div class="filter-controls">
+        <span class="filter-label">Filter</span>
+        <details
+          class="filter-collapsible"
+          data-filter-collapsible
+          data-has-active="{{ 'true' if filters.has_active_filters else 'false' }}"
+          {% if filters.has_active_filters %}open{% endif %}
+        >
+          <summary class="filter-toggle">
+            <span class="filter-toggle-text">
+              <span class="filter-toggle-state filter-toggle-state--closed">Click to Filter…</span>
+              <span class="filter-toggle-state filter-toggle-state--open">Filter Options</span>
+            </span>
+            {% if filters.has_active_filters %}
+              <span class="filter-indicator" aria-hidden="true">•</span>
+              <span class="sr-only">Active filters applied</span>
+            {% endif %}
+          </summary>
+          <div class="filter-fields">
+            <div class="field-group">
+              <label for="search">Search</label>
+              <input type="search" id="search" name="q" placeholder="Search tickets" value="{{ filters.search or '' }}" />
+            </div>
+            <div class="field-group">
+              <label for="status">Status</label>
+              <select id="status" name="status">
+                <option value="">All</option>
+                {% for status in config.workflow %}
+                  <option value="{{ status }}" {% if filters.status == status %}selected{% endif %}>{{ status }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="field-group">
+              <label for="priority">Priority</label>
+              <select id="priority" name="priority">
+                <option value="">All</option>
+                {% for priority in priorities %}
+                  <option value="{{ priority }}" {% if filters.priority == priority %}selected{% endif %}>{{ priority }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="field-group">
+              <label for="tag">Tags</label>
+              <select id="tag" name="tag" multiple size="3">
+                {% for tag in available_tags %}
+                  <option value="{{ tag.name }}" {% if tag.name in filters.tags %}selected{% endif %}>{{ tag.name }}</option>
+                {% endfor %}
+              </select>
+              <div class="tag-mode">
+                <label><input type="radio" name="tag_mode" value="any" {% if filters.tag_mode != 'all' %}checked{% endif %} /> Any</label>
+                <label><input type="radio" name="tag_mode" value="all" {% if filters.tag_mode == 'all' %}checked{% endif %} /> All</label>
+              </div>
+            </div>
+            <div class="actions filter-actions" role="group" aria-label="Filter actions">
+              <button type="submit" class="button primary">Apply</button>
+              <a
+                href="{{ url_for('tickets.list_tickets', compact=compact_value) }}"
+                class="button"
+              >
+                Reset
+              </a>
             </div>
           </div>
-          <div class="actions filter-actions" role="group" aria-label="Filter actions">
-            <button type="submit" class="button primary">Apply</button>
-            <a
-              href="{{ url_for('tickets.list_tickets', compact=compact_value) }}"
-              class="button"
-            >
-              Reset
-            </a>
-          </div>
-        </div>
-      </details>
+        </details>
+      </div>
       <div class="sort-controls" data-sort-controls>
         <span class="sort-label">Sort by</span>
         <div class="sort-button-group" role="group" aria-label="Sort tickets">


### PR DESCRIPTION
## Summary
- wrap the filter `<details>` element in a new `.filter-controls` container with a `.filter-label` header and dual-state summary text
- update the stylesheet so `.filter-label` shares the sort label styling and the summary text softens until the panel is opened or has active filters
- confirm the details/summary interaction keeps keyboard focus and screen reader semantics intact while capturing a UI screenshot

## Testing
- pytest *(no tests found)*
- python -m compileall .
- flake8 *(unavailable – proxy blocked installation)*

------
https://chatgpt.com/codex/tasks/task_e_68f94d55fcd4832ca705dbba7ca404b8