### PR TITLE
Add configurable clipboard summaries with copy support

### DIFF
--- a/config.json
+++ b/config.json
@@ -50,5 +50,28 @@
       "background": "#1e293b",
       "text": "#e2e8f0"
     }
+  },
+  "clipboard_summary": {
+    "html_sections": [
+      "header",
+      "meta",
+      "people",
+      "description",
+      "links",
+      "notes",
+      "tags",
+      "updates"
+    ],
+    "text_sections": [
+      "header",
+      "meta",
+      "people",
+      "description",
+      "links",
+      "notes",
+      "tags",
+      "updates"
+    ],
+    "updates_limit": 1
   }
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -771,6 +771,62 @@ body.compact .filter-fields .filter-actions {
   color: var(--text-muted);
 }
 
+.ticket-card-actions,
+.ticket-detail .ticket-card-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.clipboard-control {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.45rem;
+}
+
+.clipboard-button {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--text-muted);
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.clipboard-button:hover,
+.clipboard-button:focus-visible {
+  color: #f8fafc;
+  border-color: rgba(56, 189, 248, 0.6);
+  background: rgba(56, 189, 248, 0.22);
+  transform: translateY(-1px);
+  text-decoration: none;
+}
+
+.clipboard-button.is-success {
+  color: #22c55e;
+  border-color: rgba(34, 197, 94, 0.65);
+  background: rgba(34, 197, 94, 0.16);
+}
+
+.clipboard-button.is-error {
+  color: #f87171;
+  border-color: rgba(248, 113, 113, 0.6);
+  background: rgba(248, 113, 113, 0.16);
+}
+
+.clipboard-button.is-warning {
+  color: #fbbf24;
+  border-color: rgba(251, 191, 36, 0.58);
+  background: rgba(251, 191, 36, 0.16);
+}
+
+.clipboard-status {
+  min-height: 1rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-align: right;
+}
+
 .priority {
   display: inline-flex;
 }
@@ -967,6 +1023,41 @@ body.compact .filter-fields .filter-actions {
   justify-content: space-between;
   color: var(--text-muted);
   font-size: 0.8rem;
+}
+
+.clipboard-fallback {
+  margin-top: 1.25rem;
+  padding: 1rem;
+  border-radius: 0.9rem;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.clipboard-fallback[hidden] {
+  display: none;
+}
+
+.clipboard-fallback p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.clipboard-fallback-text {
+  width: 100%;
+  min-height: 8rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.78);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  padding: 0.75rem;
+  resize: vertical;
 }
 
 .ticket-detail {

--- a/static/js/clipboard.js
+++ b/static/js/clipboard.js
@@ -1,0 +1,168 @@
+const buttons = document.querySelectorAll('[data-clipboard-button]');
+
+if (buttons.length) {
+  const resetTimers = new WeakMap();
+  const canWriteAdvanced =
+    typeof window.ClipboardItem !== 'undefined' &&
+    navigator.clipboard &&
+    typeof navigator.clipboard.write === 'function';
+  const canWriteText =
+    navigator.clipboard && typeof navigator.clipboard.writeText === 'function';
+
+  const clearStatusLater = (button, statusEl) => {
+    const existing = resetTimers.get(button);
+    if (existing) {
+      window.clearTimeout(existing);
+    }
+    const timer = window.setTimeout(() => {
+      if (statusEl) {
+        statusEl.textContent = '';
+      }
+      button.classList.remove('is-success', 'is-error', 'is-warning');
+      resetTimers.delete(button);
+    }, 2400);
+    resetTimers.set(button, timer);
+  };
+
+  const setStatus = (button, statusEl, message, state) => {
+    if (statusEl) {
+      statusEl.textContent = message;
+    }
+    button.classList.remove('is-success', 'is-error', 'is-warning');
+    if (state) {
+      button.classList.add(`is-${state}`);
+      clearStatusLater(button, statusEl);
+    }
+  };
+
+  const hideFallback = (fallbackEl) => {
+    if (!fallbackEl) {
+      return;
+    }
+    if (!fallbackEl.hidden) {
+      fallbackEl.hidden = true;
+      const textarea = fallbackEl.querySelector('[data-clipboard-textarea]');
+      if (textarea) {
+        textarea.blur();
+      }
+    }
+  };
+
+  const legacyCopy = (text) => {
+    if (!text || typeof document.execCommand !== 'function') {
+      return false;
+    }
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '-1000px';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    let success = false;
+    try {
+      success = document.execCommand('copy');
+    } catch (error) {
+      success = false;
+    }
+    textarea.remove();
+    return success;
+  };
+
+  const showFallback = (fallbackEl, text) => {
+    if (!fallbackEl) {
+      return false;
+    }
+    const textarea = fallbackEl.querySelector('[data-clipboard-textarea]');
+    if (!textarea) {
+      return false;
+    }
+    fallbackEl.hidden = false;
+    textarea.value = text;
+    textarea.focus();
+    textarea.select();
+    fallbackEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    return true;
+  };
+
+  const copyAdvanced = async (html, text) => {
+    const payload = {};
+    if (html) {
+      payload['text/html'] = new Blob([html], { type: 'text/html' });
+    }
+    payload['text/plain'] = new Blob([text], { type: 'text/plain' });
+    await navigator.clipboard.write([new ClipboardItem(payload)]);
+  };
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', async () => {
+      const container = button.closest('[data-clipboard-container]');
+      if (!container) {
+        return;
+      }
+
+      const statusEl = container.querySelector('[data-clipboard-status]');
+      const fallbackEl = container.querySelector('[data-clipboard-fallback]');
+      const htmlTemplate = container.querySelector('[data-clipboard-html]');
+      const textTemplate = container.querySelector('[data-clipboard-text]');
+
+      const htmlContent = htmlTemplate ? htmlTemplate.innerHTML.trim() : '';
+      const htmlTextFallback = htmlTemplate
+        ? htmlTemplate.content.textContent.trim()
+        : '';
+      const textContent = textTemplate
+        ? textTemplate.content.textContent.trim()
+        : '';
+
+      const fallbackText = textContent || htmlTextFallback || '';
+
+      if (!fallbackText && !htmlContent) {
+        setStatus(button, statusEl, 'Nothing to copy yet.', 'error');
+        return;
+      }
+
+      try {
+        if (canWriteAdvanced) {
+          await copyAdvanced(htmlContent, fallbackText);
+          hideFallback(fallbackEl);
+          setStatus(button, statusEl, 'Summary copied.', 'success');
+          return;
+        }
+      } catch (error) {
+        console.warn('Advanced clipboard copy failed', error);
+      }
+
+      if (canWriteText && fallbackText) {
+        try {
+          await navigator.clipboard.writeText(fallbackText);
+          hideFallback(fallbackEl);
+          setStatus(button, statusEl, 'Summary copied.', 'success');
+          return;
+        } catch (error) {
+          console.warn('Clipboard writeText failed', error);
+        }
+      }
+
+      if (legacyCopy(fallbackText)) {
+        hideFallback(fallbackEl);
+        setStatus(button, statusEl, 'Summary copied.', 'success');
+        return;
+      }
+
+      if (showFallback(fallbackEl, fallbackText)) {
+        setStatus(
+          button,
+          statusEl,
+          'Clipboard unavailable. Text selected below.',
+          'warning',
+        );
+        return;
+      }
+
+      setStatus(button, statusEl, 'Clipboard unavailable.', 'error');
+    });
+  });
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -94,5 +94,6 @@
     <footer class="app-footer">
       <p>Uploads stored in <code>{{ app_config.uploads_path }}</code>. Customize colors and SLAs via the JSON config.</p>
     </footer>
+    {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -112,6 +112,7 @@
     {% for ticket in tickets %}
       <article
         class="ticket-card{% if ticket.is_overdue %} is-overdue{% endif %}"
+        data-clipboard-container
         data-overdue="{{ 'true' if ticket.is_overdue else 'false' }}"
         style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};"
         {% if is_compact and ticket.compact_tooltip %}
@@ -165,9 +166,37 @@
               </span>
             </div>
           </div>
-          <div class="timestamps">
-            <span title="Created">🕒 {{ ticket.created_at.strftime('%b %d, %Y') }}</span>
-            <span title="Updated">🔄 {{ ticket.updated_at.strftime('%b %d, %Y %H:%M') }}</span>
+          <div class="ticket-card-actions">
+            <div class="timestamps">
+              <span title="Created">🕒 {{ ticket.created_at.strftime('%b %d, %Y') }}</span>
+              <span title="Updated">🔄 {{ ticket.updated_at.strftime('%b %d, %Y %H:%M') }}</span>
+            </div>
+            <div class="clipboard-control">
+              <button
+                type="button"
+                class="icon-button clipboard-button"
+                data-clipboard-button
+                aria-describedby="clipboard-status-{{ ticket.id }}"
+                title="Copy ticket summary"
+              >
+                <span class="icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                    <path
+                      d="M16 3H5a2 2 0 0 0-2 2v11h2V5h11V3zm3 4H9a2 2 0 0 0-2 2v12h12a2 2 0 0 0 2-2V7z"
+                      fill="currentColor"
+                    ></path>
+                  </svg>
+                </span>
+                <span class="sr-only">Copy summary</span>
+              </button>
+              <span
+                class="clipboard-status"
+                id="clipboard-status-{{ ticket.id }}"
+                data-clipboard-status
+                role="status"
+                aria-live="polite"
+              ></span>
+            </div>
           </div>
         </header>
         <p class="description">{{ ticket.description|truncate(240) }}</p>
@@ -204,6 +233,16 @@
           <span>{{ ticket.updates|length }} updates</span>
           <span>{{ ticket.attachments|length }} attachments</span>
         </footer>
+        <div class="clipboard-fallback" data-clipboard-fallback hidden>
+          <p>Clipboard access isn't available. Select and copy the summary below.</p>
+          <textarea
+            class="clipboard-fallback-text"
+            data-clipboard-textarea
+            readonly
+          >{{- ticket.clipboard_summary.text | e -}}</textarea>
+        </div>
+        <template data-clipboard-html>{{ ticket.clipboard_summary.html|safe }}</template>
+        <template data-clipboard-text>{{- ticket.clipboard_summary.text -}}</template>
       </article>
     {% endfor %}
   {% else %}
@@ -275,4 +314,9 @@
     });
   });
 </script>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script type="module" src="{{ url_for('static', filename='js/clipboard.js') }}"></script>
 {% endblock %}

--- a/templates/partials/ticket_clipboard_summary.html
+++ b/templates/partials/ticket_clipboard_summary.html
@@ -1,0 +1,100 @@
+<article class="ticket-clipboard-summary">
+  {% if 'header' in sections %}
+    <header>
+      <h1>Ticket #{{ ticket.id }} · {{ ticket.title }}</h1>
+      <p>
+        <strong>Created:</strong>
+        {{ ticket.created_at.strftime('%b %d, %Y %H:%M') if ticket.created_at else '—' }}<br />
+        <strong>Updated:</strong>
+        {{ ticket.updated_at.strftime('%b %d, %Y %H:%M') if ticket.updated_at else '—' }}
+      </p>
+      {% if ticket_url %}
+        <p><strong>Link:</strong> <a href="{{ ticket_url }}">{{ ticket_url }}</a></p>
+      {% endif %}
+    </header>
+  {% endif %}
+
+  {% if 'meta' in sections %}
+    <section>
+      <h2>Details</h2>
+      <ul>
+        <li><strong>Status:</strong> {{ ticket.status }}</li>
+        <li><strong>Priority:</strong> {{ ticket.priority }}</li>
+        <li><strong>Due:</strong> {{ ticket.due_badge_label }}</li>
+        {% if ticket.sla_countdown %}
+          <li><strong>SLA:</strong> {{ ticket.sla_countdown }}</li>
+        {% endif %}
+      </ul>
+    </section>
+  {% endif %}
+
+  {% if 'people' in sections and (ticket.requester or ticket.watchers) %}
+    <section>
+      <h2>People</h2>
+      <ul>
+        {% if ticket.requester %}
+          <li><strong>Requester:</strong> {{ ticket.requester }}</li>
+        {% endif %}
+        {% if ticket.watchers %}
+          <li><strong>Watchers:</strong> {{ ticket.watchers|join(', ') }}</li>
+        {% endif %}
+      </ul>
+    </section>
+  {% endif %}
+
+  {% if 'description' in sections and ticket.description %}
+    <section>
+      <h2>Description</h2>
+      <p>{{ ticket.description|urlize|replace('\n', '<br />')|safe }}</p>
+    </section>
+  {% endif %}
+
+  {% if 'links' in sections and ticket.links %}
+    <section>
+      <h2>Links</h2>
+      <p>{{ ticket.links|urlize|replace('\n', '<br />')|safe }}</p>
+    </section>
+  {% endif %}
+
+  {% if 'notes' in sections and ticket.notes %}
+    <section>
+      <h2>Notes</h2>
+      <p>{{ ticket.notes|urlize|replace('\n', '<br />')|safe }}</p>
+    </section>
+  {% endif %}
+
+  {% if 'tags' in sections and ticket.tags %}
+    <section>
+      <h2>Tags</h2>
+      <ul>
+        {% for tag in ticket.tags %}
+          <li>{{ tag.name }}</li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+
+  {% if 'updates' in sections and updates %}
+    <section>
+      <h2>Recent Updates</h2>
+      <ol>
+        {% for update in updates %}
+          <li>
+            <p>
+              <strong>{{ update.created_at.strftime('%b %d, %Y %H:%M') }}</strong>
+              by
+              {{ 'System' if update.is_system else (update.author or config.default_submitted_by) }}
+            </p>
+            {% if update.status_from or update.status_to %}
+              <p>
+                <strong>Status:</strong>
+                {{ update.status_from or '—' }} → {{ update.status_to or '—' }}
+              </p>
+            {% endif %}
+            <p>{{ update.body|urlize|replace('\n', '<br />')|safe }}</p>
+          </li>
+        {% endfor %}
+      </ol>
+    </section>
+  {% endif %}
+</article>

--- a/templates/partials/ticket_clipboard_summary.txt
+++ b/templates/partials/ticket_clipboard_summary.txt
@@ -1,0 +1,56 @@
+{% if 'header' in sections %}
+Ticket #{{ ticket.id }} · {{ ticket.title }}
+Created: {{ ticket.created_at.strftime('%b %d, %Y %H:%M') if ticket.created_at else '—' }}
+Updated: {{ ticket.updated_at.strftime('%b %d, %Y %H:%M') if ticket.updated_at else '—' }}
+{% if ticket_url %}Link: {{ ticket_url }}
+{% endif %}
+
+{% endif %}
+{% if 'meta' in sections %}
+Status: {{ ticket.status }}
+Priority: {{ ticket.priority }}
+Due: {{ ticket.due_badge_label }}
+{% if ticket.sla_countdown %}SLA: {{ ticket.sla_countdown }}
+{% endif %}
+
+{% endif %}
+{% if 'people' in sections and (ticket.requester or ticket.watchers) %}
+{% if ticket.requester %}Requester: {{ ticket.requester }}
+{% endif %}
+{% if ticket.watchers %}Watchers: {{ ticket.watchers|join(', ') }}
+{% endif %}
+
+{% endif %}
+{% if 'description' in sections and ticket.description %}
+Description:
+{% for line in ticket.description.splitlines() %}  {{ line }}
+{% endfor %}
+
+{% endif %}
+{% if 'links' in sections and ticket.links %}
+Links:
+{% for line in ticket.links.splitlines() %}  {{ line }}
+{% endfor %}
+
+{% endif %}
+{% if 'notes' in sections and ticket.notes %}
+Notes:
+{% for line in ticket.notes.splitlines() %}  {{ line }}
+{% endfor %}
+
+{% endif %}
+{% if 'tags' in sections and ticket.tags %}
+Tags: {{ ticket.tags|map(attribute='name')|join(', ') }}
+
+{% endif %}
+{% if 'updates' in sections and updates %}
+Recent Updates:
+{% for update in updates %}- {{ update.created_at.strftime('%b %d, %Y %H:%M') }} by {{ 'System' if update.is_system else (update.author or config.default_submitted_by) }}
+{% if update.status_from or update.status_to %}  Status: {{ update.status_from or '—' }} → {{ update.status_to or '—' }}
+{% endif %}{% for line in update.body.splitlines() %}
+  {{ line }}
+{% endfor %}
+{% if not loop.last %}
+
+{% endif %}{% endfor %}
+{% endif %}

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -5,6 +5,7 @@
 {% set compact_value = '1' if is_compact else '0' %}
 <article
   class="ticket-detail{% if ticket.is_overdue %} is-overdue{% endif %}"
+  data-clipboard-container
   data-overdue="{{ 'true' if ticket.is_overdue else 'false' }}"
   style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }}; --ticket-title-color: {{ ticket_title_color|default('#f8fafc') }};"
 >
@@ -47,11 +48,50 @@
         </span>
       </div>
     </div>
-    <div class="timestamps">
-      <span>Created {{ ticket.created_at.strftime('%b %d, %Y %H:%M') }}</span>
-      <span>Updated {{ ticket.updated_at.strftime('%b %d, %Y %H:%M') }}</span>
+    <div class="ticket-card-actions">
+      <div class="timestamps">
+        <span>Created {{ ticket.created_at.strftime('%b %d, %Y %H:%M') }}</span>
+        <span>Updated {{ ticket.updated_at.strftime('%b %d, %Y %H:%M') }}</span>
+      </div>
+      <div class="clipboard-control">
+        <button
+          type="button"
+          class="icon-button clipboard-button"
+          data-clipboard-button
+          aria-describedby="clipboard-status-{{ ticket.id }}"
+          title="Copy ticket summary"
+        >
+          <span class="icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+              <path
+                d="M16 3H5a2 2 0 0 0-2 2v11h2V5h11V3zm3 4H9a2 2 0 0 0-2 2v12h12a2 2 0 0 0 2-2V7z"
+                fill="currentColor"
+              ></path>
+            </svg>
+          </span>
+          <span class="sr-only">Copy summary</span>
+        </button>
+        <span
+          class="clipboard-status"
+          id="clipboard-status-{{ ticket.id }}"
+          data-clipboard-status
+          role="status"
+          aria-live="polite"
+        ></span>
+      </div>
     </div>
   </header>
+
+  <div class="clipboard-fallback" data-clipboard-fallback hidden>
+    <p>Clipboard access isn't available. Select and copy the summary below.</p>
+    <textarea
+      class="clipboard-fallback-text"
+      data-clipboard-textarea
+      readonly
+    >{{- ticket.clipboard_summary.text | e -}}</textarea>
+  </div>
+  <template data-clipboard-html>{{ ticket.clipboard_summary.html|safe }}</template>
+  <template data-clipboard-text>{{- ticket.clipboard_summary.text -}}</template>
 
   <section class="detail-grid">
     <div>
@@ -234,4 +274,9 @@
     updateToggleHold();
   }
 </script>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script type="module" src="{{ url_for('static', filename='js/clipboard.js') }}"></script>
 {% endblock %}

--- a/tickettracker/summary.py
+++ b/tickettracker/summary.py
@@ -1,0 +1,88 @@
+"""Utilities for composing clipboard-ready ticket summaries."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List, Sequence
+
+from flask import render_template, url_for
+
+from .config import AppConfig
+from .models import Ticket, TicketUpdate
+
+
+@dataclass
+class TicketClipboardSummary:
+    """Rendered clipboard payload for a ticket."""
+
+    html: str
+    text: str
+
+
+def _normalize_sections(values: Iterable[str]) -> List[str]:
+    sections: List[str] = []
+    for value in values:
+        text = str(value or "").strip().lower()
+        if not text or text in sections:
+            continue
+        sections.append(text)
+    return sections
+
+
+def _recent_updates(ticket: Ticket, limit: int) -> List[TicketUpdate]:
+    if limit <= 0:
+        return []
+
+    updates = sorted(
+        ticket.updates,
+        key=lambda update: update.created_at or datetime.min,
+        reverse=True,
+    )
+    return updates[:limit]
+
+
+def build_ticket_clipboard_summary(
+    ticket: Ticket,
+    config: AppConfig,
+    *,
+    html_sections: Sequence[str] | None = None,
+    text_sections: Sequence[str] | None = None,
+) -> TicketClipboardSummary:
+    """Render HTML and plain-text clipboard payloads for ``ticket``."""
+
+    summary_config = config.clipboard_summary
+
+    resolved_html_sections = _normalize_sections(
+        html_sections or summary_config.sections_for_html()
+    )
+    resolved_text_sections = _normalize_sections(
+        text_sections or summary_config.sections_for_text()
+    )
+
+    updates_limit = summary_config.max_updates()
+    updates = _recent_updates(ticket, updates_limit)
+
+    try:
+        ticket_url = url_for("tickets.ticket_detail", ticket_id=ticket.id, _external=True)
+    except RuntimeError:
+        ticket_url = None
+
+    html = render_template(
+        "partials/ticket_clipboard_summary.html",
+        ticket=ticket,
+        config=config,
+        sections=resolved_html_sections,
+        updates=updates,
+        ticket_url=ticket_url,
+    ).strip()
+
+    text = render_template(
+        "partials/ticket_clipboard_summary.txt",
+        ticket=ticket,
+        config=config,
+        sections=resolved_text_sections,
+        updates=updates,
+        ticket_url=ticket_url,
+    ).strip()
+
+    return TicketClipboardSummary(html=html, text=text)

--- a/tickettracker/views/tickets.py
+++ b/tickettracker/views/tickets.py
@@ -24,6 +24,7 @@ from werkzeug.utils import secure_filename
 from ..config import AppConfig
 from ..extensions import db
 from ..models import Attachment, Tag, Ticket, TicketUpdate
+from ..summary import build_ticket_clipboard_summary
 
 
 tickets_bp = Blueprint("tickets", __name__)
@@ -480,6 +481,10 @@ def list_tickets():
         _annotate_ticket_sla(ticket, config, now)
         _annotate_due_state(ticket, config)
         ticket.compact_tooltip = _compose_compact_tooltip(ticket)  # type: ignore[attr-defined]
+        ticket.clipboard_summary = build_ticket_clipboard_summary(  # type: ignore[attr-defined]
+            ticket,
+            config,
+        )
 
     available_tags = Tag.query.order_by(Tag.name).all()
 
@@ -527,6 +532,10 @@ def ticket_detail(ticket_id: int):
     )  # type: ignore[attr-defined]
     _annotate_ticket_sla(ticket, config)
     _annotate_due_state(ticket, config)
+    ticket.clipboard_summary = build_ticket_clipboard_summary(  # type: ignore[attr-defined]
+        ticket,
+        config,
+    )
     return render_template(
         "ticket_detail.html",
         ticket=ticket,


### PR DESCRIPTION
## Summary
- add clipboard summary defaults to the config loader and expose them via `AppConfig`
- render reusable HTML and plain-text ticket summaries and surface copy buttons in ticket views
- provide clipboard scripting, fallback templates, and styling to support copy-to-clipboard interactions

## Testing
- pytest
- python -m compileall tickettracker

------
https://chatgpt.com/codex/tasks/task_e_68f94f6dd89c832c83b73f0adcfcac52