### PR TITLE
Add settings management UI and persist configuration updates

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -50,6 +50,15 @@
           <span class="sr-only">Create a new ticket</span>
         </a>
         <a
+          href="{{ url_for('settings.view_settings', compact=compact_value) }}"
+          class="icon-button"
+          aria-label="Configure settings"
+          title="Configure settings"
+        >
+          <span class="icon" aria-hidden="true">⚙️</span>
+          <span class="sr-only">Settings</span>
+        </a>
+        <a
           href="{{ compact_toggle_url|default(request.url) }}"
           class="button icon-button toggle-compact"
           role="switch"

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,115 @@
+{% extends "base.html" %}
+{% set is_compact = compact_mode|default(true) %}
+{% set compact_value = '1' if is_compact else '0' %}
+{% block title %}Settings · TicketTracker{% endblock %}
+{% block content %}
+  <section class="panel settings-panel">
+    <h2>Application settings</h2>
+    <p class="help">
+      {% if config.source_path %}
+        Changes are saved to <code>{{ config.source_path }}</code>.
+      {% else %}
+        Changes are saved to the default configuration file.
+      {% endif %}
+    </p>
+    <form
+      method="post"
+      action="{{ url_for('settings.view_settings', compact=compact_value) }}"
+      class="settings-form"
+    >
+      <div class="field-group">
+        <label for="default_submitted_by">Default submitted by</label>
+        <input
+          type="text"
+          id="default_submitted_by"
+          name="default_submitted_by"
+          value="{{ form.default_submitted_by|default('') }}"
+          required
+        />
+      </div>
+
+      <div class="field-group">
+        <label for="priorities">Priorities</label>
+        <textarea
+          id="priorities"
+          name="priorities"
+          rows="4"
+          required
+        >{{- form.priorities|default('') -}}</textarea>
+        <p class="help">Enter one priority per line, ordered from lowest to highest.</p>
+      </div>
+
+      <div class="field-group">
+        <label for="hold_reasons">Hold reasons</label>
+        <textarea
+          id="hold_reasons"
+          name="hold_reasons"
+          rows="4"
+          required
+        >{{- form.hold_reasons|default('') -}}</textarea>
+        <p class="help">Use one reason per line to populate the on-hold dropdown.</p>
+      </div>
+
+      <div class="field-group">
+        <label for="workflow">Workflow statuses</label>
+        <textarea
+          id="workflow"
+          name="workflow"
+          rows="4"
+          required
+        >{{- form.workflow|default('') -}}</textarea>
+        <p class="help">List statuses in the order they should appear in dropdowns.</p>
+      </div>
+
+      <div class="field-group">
+        <label for="html_sections">Clipboard HTML sections</label>
+        <textarea
+          id="html_sections"
+          name="html_sections"
+          rows="4"
+        >{{- form.html_sections|default('') -}}</textarea>
+        <p class="help">Customize the sections used when generating HTML clipboard summaries.</p>
+      </div>
+
+      <div class="field-group">
+        <label for="text_sections">Clipboard text sections</label>
+        <textarea
+          id="text_sections"
+          name="text_sections"
+          rows="4"
+        >{{- form.text_sections|default('') -}}</textarea>
+        <p class="help">Leave blank to reuse the HTML section list for plain text summaries.</p>
+      </div>
+
+      <div class="field-group">
+        <label for="updates_limit">Clipboard updates limit</label>
+        <input
+          type="number"
+          id="updates_limit"
+          name="updates_limit"
+          min="0"
+          value="{{ form.updates_limit|default('') }}"
+        />
+        <p class="help">Limit the number of recent updates included in clipboard exports.</p>
+      </div>
+
+      <div class="field-group checkbox">
+        <label class="checkbox-label" for="demo_mode">
+          <input
+            type="checkbox"
+            id="demo_mode"
+            name="demo_mode"
+            {% if form.demo_mode %}checked{% endif %}
+          />
+          <span>Enable demo mode enhancements</span>
+        </label>
+        <p class="help">Demo mode enables sample data helpers and other onboarding aids.</p>
+      </div>
+
+      <div class="actions">
+        <button type="submit" class="button primary">Save changes</button>
+        <a class="button" href="{{ url_for('tickets.list_tickets', compact=compact_value) }}">Cancel</a>
+      </div>
+    </form>
+  </section>
+{% endblock %}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,103 @@
+"""Tests for the configuration settings workflow."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from flask import current_app
+
+from tickettracker.app import create_app
+from tickettracker.config import DEFAULT_CONFIG, load_config
+
+
+def _write_config(target: Path, data: dict) -> Path:
+    target.write_text(json.dumps(data, indent=2))
+    return target
+
+
+def _default_config() -> dict:
+    return json.loads(json.dumps(DEFAULT_CONFIG))
+
+
+def test_load_config_records_source_path(tmp_path):
+    config_data = _default_config()
+    config_data["database"]["uri"] = "sqlite:///:memory:"
+    config_path = _write_config(tmp_path / "config.json", config_data)
+
+    config = load_config(config_path)
+
+    assert config.source_path == config_path.resolve()
+    payload = config.to_json_dict()
+    assert payload["demo_mode"] is False
+    assert payload["database"]["uri"].endswith("/:memory:")
+
+
+def test_settings_update_persists_between_app_starts(tmp_path):
+    config_data = _default_config()
+    database_path = tmp_path / "app.db"
+    uploads_dir = "uploads"
+    config_data["database"]["uri"] = f"sqlite:///{database_path}"
+    config_data["uploads"]["directory"] = uploads_dir
+    config_path = _write_config(tmp_path / "config.json", config_data)
+
+    app = create_app(config_path)
+
+    client = app.test_client()
+    response = client.post(
+        "/settings",
+        data={
+            "default_submitted_by": "Operations Team",
+            "priorities": "Low\nMedium\nHigh\nUrgent",
+            "hold_reasons": "Awaiting info\nReview pending",
+            "workflow": "New\nActive\nDone",
+            "html_sections": "header\nsummary",
+            "text_sections": "header\nsummary\nnotes",
+            "updates_limit": "3",
+            "demo_mode": "on",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+
+    persisted = json.loads(config_path.read_text())
+    assert persisted["default_submitted_by"] == "Operations Team"
+    assert persisted["priorities"] == ["Low", "Medium", "High", "Urgent"]
+    assert persisted["hold_reasons"] == ["Awaiting info", "Review pending"]
+    assert persisted["workflow"] == ["New", "Active", "Done"]
+    assert persisted["clipboard_summary"]["html_sections"] == ["header", "summary"]
+    assert persisted["clipboard_summary"]["text_sections"] == [
+        "header",
+        "summary",
+        "notes",
+    ]
+    assert persisted["clipboard_summary"]["updates_limit"] == 3
+    assert persisted["demo_mode"] is True
+
+    with app.app_context():
+        updated_config = current_app.config["APP_CONFIG"]
+        assert updated_config.demo_mode is True
+        assert updated_config.priorities == ["Low", "Medium", "High", "Urgent"]
+        assert current_app.config["DEMO_MODE"] is True
+
+    new_app = create_app(config_path)
+    with new_app.app_context():
+        reloaded_config = current_app.config["APP_CONFIG"]
+        assert reloaded_config.demo_mode is True
+        assert reloaded_config.priorities == ["Low", "Medium", "High", "Urgent"]
+        assert reloaded_config.hold_reasons == ["Awaiting info", "Review pending"]
+        assert reloaded_config.clipboard_summary.html_sections == [
+            "header",
+            "summary",
+        ]
+        assert reloaded_config.clipboard_summary.text_sections == [
+            "header",
+            "summary",
+            "notes",
+        ]
+        assert reloaded_config.clipboard_summary.updates_limit == 3

--- a/tickettracker/views/settings.py
+++ b/tickettracker/views/settings.py
@@ -1,0 +1,203 @@
+"""Application settings management views."""
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Dict, List
+
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+
+from ..config import AppConfig, save_config
+
+
+settings_bp = Blueprint("settings", __name__)
+
+
+def _app_config() -> AppConfig:
+    return current_app.config["APP_CONFIG"]
+
+
+def _is_compact_mode() -> bool:
+    value = request.args.get("compact")
+    if value is None:
+        return True
+
+    normalized = value.strip().lower()
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    return True
+
+
+def _compact_query_value(compact_mode: bool) -> str:
+    return "1" if compact_mode else "0"
+
+
+def _build_compact_toggle_url(endpoint: str, compact_mode: bool, **values: object) -> str:
+    query_args: Dict[str, List[str]] = {key: list(items) for key, items in request.args.lists()}
+    query_args["compact"] = [_compact_query_value(not compact_mode)]
+
+    flattened: Dict[str, object] = {
+        key: value if len(value) != 1 else value[0]
+        for key, value in query_args.items()
+    }
+    return url_for(endpoint, **values, **flattened)
+
+
+def _parse_multiline_field(raw_value: str | None) -> List[str]:
+    if not raw_value:
+        return []
+
+    entries: List[str] = []
+    seen: set[str] = set()
+    for segment in raw_value.replace(",", "\n").splitlines():
+        text = segment.strip()
+        if not text or text in seen:
+            continue
+        entries.append(text)
+        seen.add(text)
+    return entries
+
+
+def _form_defaults(config: AppConfig) -> Dict[str, object]:
+    html_sections = (
+        list(config.clipboard_summary.html_sections)
+        or config.clipboard_summary.sections_for_html()
+    )
+    text_sections = (
+        list(config.clipboard_summary.text_sections)
+        or config.clipboard_summary.sections_for_text()
+    )
+
+    return {
+        "default_submitted_by": config.default_submitted_by,
+        "priorities": "\n".join(config.priorities),
+        "hold_reasons": "\n".join(config.hold_reasons),
+        "workflow": "\n".join(config.workflow),
+        "html_sections": "\n".join(html_sections),
+        "text_sections": "\n".join(text_sections),
+        "updates_limit": str(config.clipboard_summary.updates_limit),
+        "demo_mode": config.demo_mode,
+    }
+
+
+@settings_bp.route("/settings", methods=["GET", "POST"])
+def view_settings():
+    config = _app_config()
+    compact_mode = _is_compact_mode()
+
+    form_data = _form_defaults(config)
+
+    if request.method == "POST":
+        default_submitted_by = request.form.get("default_submitted_by", "").strip()
+        priorities_input = request.form.get("priorities", "")
+        hold_reasons_input = request.form.get("hold_reasons", "")
+        workflow_input = request.form.get("workflow", "")
+        html_sections_input = request.form.get("html_sections", "")
+        text_sections_input = request.form.get("text_sections", "")
+        updates_limit_input = request.form.get("updates_limit", "").strip()
+        demo_mode_enabled = request.form.get("demo_mode") is not None
+
+        form_data = {
+            "default_submitted_by": default_submitted_by,
+            "priorities": priorities_input,
+            "hold_reasons": hold_reasons_input,
+            "workflow": workflow_input,
+            "html_sections": html_sections_input,
+            "text_sections": text_sections_input,
+            "updates_limit": updates_limit_input,
+            "demo_mode": demo_mode_enabled,
+        }
+
+        errors: List[str] = []
+
+        priorities = _parse_multiline_field(priorities_input)
+        if not priorities:
+            errors.append("Provide at least one priority value.")
+
+        hold_reasons = _parse_multiline_field(hold_reasons_input)
+        if not hold_reasons:
+            errors.append("Provide at least one hold reason.")
+
+        workflow = _parse_multiline_field(workflow_input)
+        if not workflow:
+            errors.append("Provide at least one workflow status.")
+
+        html_sections = _parse_multiline_field(html_sections_input)
+        if not html_sections:
+            html_sections = config.clipboard_summary.sections_for_html()
+
+        text_sections = _parse_multiline_field(text_sections_input)
+        if not text_sections:
+            text_sections = html_sections or config.clipboard_summary.sections_for_text()
+
+        if not default_submitted_by:
+            errors.append("Default submitter cannot be empty.")
+
+        if updates_limit_input:
+            try:
+                updates_limit = int(updates_limit_input)
+            except ValueError:
+                errors.append("Updates limit must be a non-negative integer.")
+            else:
+                if updates_limit < 0:
+                    errors.append("Updates limit must be a non-negative integer.")
+        else:
+            updates_limit = config.clipboard_summary.updates_limit
+
+        if errors:
+            for message in errors:
+                flash(message, "error")
+        else:
+            summary = replace(
+                config.clipboard_summary,
+                html_sections=html_sections,
+                text_sections=text_sections,
+                updates_limit=updates_limit,
+            )
+
+            updated_config = replace(
+                config,
+                default_submitted_by=default_submitted_by,
+                priorities=priorities,
+                hold_reasons=hold_reasons,
+                workflow=workflow,
+                clipboard_summary=summary,
+                demo_mode=demo_mode_enabled,
+            )
+
+            try:
+                save_config(updated_config)
+            except ValueError:
+                flash(
+                    "Unable to determine configuration file path; changes were not saved.",
+                    "error",
+                )
+            else:
+                current_app.config["APP_CONFIG"] = updated_config
+                current_app.config["DEMO_MODE"] = updated_config.demo_mode
+                flash("Settings updated", "success")
+                return redirect(
+                    url_for(
+                        "settings.view_settings",
+                        compact=_compact_query_value(compact_mode),
+                    )
+                )
+
+    return render_template(
+        "settings.html",
+        config=config,
+        form=form_data,
+        compact_mode=compact_mode,
+        compact_toggle_url=_build_compact_toggle_url(
+            "settings.view_settings", compact_mode
+        ),
+    )


### PR DESCRIPTION
## Summary
- track the source config path and add helpers to serialize and save AppConfig values
- add a settings blueprint and template so operators can edit key configuration fields with validation
- expose the settings page in the navigation and cover persistence with new pytest suites

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9545d9a00832cb4e97f875a62c62c