### PR TITLE
Add demo mode dataset and management utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ The command creates the SQLite database (if missing), ensures the uploads direct
 
 Uploaded attachments are stored locally under the directory defined in the JSON configuration (defaults to `uploads/`). Backing up the database file and uploads folder is sufficient to preserve all data.
 
+### Demo mode and sample data
+
+TicketTracker ships with a comprehensive demo dataset (`tickettracker/demo_data/demo_tickets.json`) that exercises overdue, on-hold, resolved, and backlog scenarios with associated updates, tags, and attachments. Operators can enable demo mode from the **Settings → Demo mode controls** panel or via the CLI:
+
+```bash
+python -m tickettracker.cli demo enable        # load demo data and snapshot live state
+python -m tickettracker.cli demo refresh      # discard demo changes and reload the dataset
+python -m tickettracker.cli demo disable      # restore the original database and uploads
+```
+
+Enabling demo mode snapshots the current SQLite database and uploads directory inside the application instance path, replaces them with the curated demo dataset, and ensures all temporary changes are discarded when demo mode is disabled. The settings UI surfaces enable/disable/refresh buttons and shows when the dataset was last loaded so you can safely demonstrate features without risking production data.
+
 ### Workflow highlights
 - Tickets can be created, edited, filtered, and searched from the dashboard.
 - Status transitions automatically create audit-log entries on the ticket timeline.

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -441,6 +441,52 @@ body.compact .app-footer {
   box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
 }
 
+.status-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+  margin: 1.25rem 0 1.5rem;
+  padding: 0;
+}
+
+.status-item {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 1rem;
+  padding: 0.85rem 1.1rem;
+}
+
+.status-item dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 0.3rem;
+}
+
+.status-item dd {
+  margin: 0;
+  color: #f8fafc;
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.demo-mode-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.demo-mode-actions form {
+  margin: 0;
+}
+
+.demo-mode-actions .button[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .filter-form,
 .ticket-form,
 .update-form {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -112,4 +112,62 @@
       </div>
     </form>
   </section>
+
+  <section class="panel settings-panel">
+    <h2>Demo mode controls</h2>
+    <p class="help">
+      Enable demo mode to explore TicketTracker with curated sample data. The current
+      database and uploads are snapshotted and will be restored automatically when demo
+      mode is disabled.
+    </p>
+
+    <dl class="status-list">
+      <div class="status-item">
+        <dt>Status</dt>
+        <dd>
+          {% if demo_status.active %}
+            Active{% if demo_status.last_loaded_at %} (last loaded {{ demo_status.last_loaded_at }}){% endif %}
+          {% else %}
+            Disabled
+          {% endif %}
+        </dd>
+      </div>
+      <div class="status-item">
+        <dt>Dataset</dt>
+        <dd><code>{{ demo_status.dataset }}</code></dd>
+      </div>
+    </dl>
+
+    <div class="actions demo-mode-actions">
+      <form
+        method="post"
+        action="{{ url_for('settings.toggle_demo_mode', compact=compact_value) }}"
+      >
+        <input type="hidden" name="action" value="enable" />
+        <button type="submit" class="button primary" {% if demo_status.active %}disabled{% endif %}>
+          Enable demo mode
+        </button>
+      </form>
+
+      <form
+        method="post"
+        action="{{ url_for('settings.toggle_demo_mode', compact=compact_value) }}"
+      >
+        <input type="hidden" name="action" value="disable" />
+        <button type="submit" class="button" {% if not demo_status.active %}disabled{% endif %}>
+          Disable demo mode
+        </button>
+      </form>
+
+      <form
+        method="post"
+        action="{{ url_for('settings.toggle_demo_mode', compact=compact_value) }}"
+      >
+        <input type="hidden" name="action" value="refresh" />
+        <button type="submit" class="button" {% if not demo_status.active %}disabled{% endif %}>
+          Refresh demo data
+        </button>
+      </form>
+    </div>
+  </section>
 {% endblock %}

--- a/tests/test_demo_mode.py
+++ b/tests/test_demo_mode.py
@@ -1,0 +1,134 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from flask import current_app
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tickettracker.app import create_app
+from tickettracker.config import DEFAULT_CONFIG
+from tickettracker.demo import get_demo_manager
+from tickettracker.extensions import db
+from tickettracker.models import Ticket
+
+
+def _write_config(target: Path, data: dict) -> Path:
+    target.write_text(json.dumps(data, indent=2))
+    return target
+
+
+def _default_config() -> dict:
+    return json.loads(json.dumps(DEFAULT_CONFIG))
+
+
+@pytest.fixture()
+def app_with_storage(tmp_path):
+    config_data = _default_config()
+    database_path = tmp_path / "app.db"
+    uploads_path = tmp_path / "uploads"
+    config_data["database"]["uri"] = f"sqlite:///{database_path}"
+    config_data["uploads"]["directory"] = str(uploads_path)
+    config_path = _write_config(tmp_path / "config.json", config_data)
+    app = create_app(config_path)
+    return app, config_path, uploads_path
+
+
+def test_demo_mode_enable_and_disable_restores_snapshot(app_with_storage):
+    app, config_path, uploads_path = app_with_storage
+
+    with app.app_context():
+        uploads_path.mkdir(parents=True, exist_ok=True)
+        (uploads_path / "original.txt").write_text("original data", encoding="utf-8")
+
+        ticket = Ticket(
+            title="Original Ticket",
+            description="This ticket should be restored after demo mode ends.",
+            priority="Medium",
+            status="Open",
+        )
+        db.session.add(ticket)
+        db.session.commit()
+
+        manager = get_demo_manager(current_app)
+        assert manager.is_active is False
+
+        manager.enable()
+        assert manager.is_active is True
+        assert current_app.config["DEMO_MODE"] is True
+
+        demo_tickets = Ticket.query.order_by(Ticket.id).all()
+        assert len(demo_tickets) == 5
+        assert any(
+            "Gateway outage" in ticket.title for ticket in demo_tickets
+        ), "Expected seeded dataset to load."
+        assert (uploads_path / "demo" / "failover-plan.txt").exists()
+
+        manager.disable()
+        assert manager.is_active is False
+        assert current_app.config["DEMO_MODE"] is False
+
+        restored_tickets = Ticket.query.order_by(Ticket.id).all()
+        assert len(restored_tickets) == 1
+        assert restored_tickets[0].title == "Original Ticket"
+        assert (uploads_path / "original.txt").read_text(encoding="utf-8") == "original data"
+        assert not (uploads_path / "demo").exists()
+
+        persisted = json.loads(config_path.read_text())
+        assert persisted["demo_mode"] is False
+
+
+def test_demo_mode_refresh_resets_changes(app_with_storage):
+    app, _, uploads_path = app_with_storage
+
+    with app.app_context():
+        manager = get_demo_manager(current_app)
+        manager.enable()
+
+        ticket = Ticket.query.filter(Ticket.title.contains("Gateway outage")).first()
+        assert ticket is not None
+        ticket.title = "Modified title"
+        db.session.commit()
+
+        manager.refresh()
+
+        refreshed = Ticket.query.filter(Ticket.title.contains("Gateway outage")).first()
+        assert refreshed is not None
+        assert refreshed.title == "Gateway outage affecting checkout"
+        assert (uploads_path / "demo" / "failover-plan.txt").exists()
+
+
+def test_settings_toggle_demo_mode_route(app_with_storage):
+    app, config_path, uploads_path = app_with_storage
+
+    client = app.test_client()
+
+    response = client.post("/settings/demo-mode", data={"action": "enable"}, follow_redirects=True)
+    assert response.status_code == 200
+
+    with app.app_context():
+        manager = get_demo_manager(current_app)
+        assert manager.is_active is True
+        assert current_app.config["APP_CONFIG"].demo_mode is True
+        assert Ticket.query.count() == 5
+        assert (uploads_path / "demo" / "duplicate-report.csv").exists()
+
+    response = client.post("/settings/demo-mode", data={"action": "refresh"}, follow_redirects=True)
+    assert response.status_code == 200
+
+    response = client.post("/settings/demo-mode", data={"action": "disable"}, follow_redirects=True)
+    assert response.status_code == 200
+
+    with app.app_context():
+        manager = get_demo_manager(current_app)
+        assert manager.is_active is False
+        assert current_app.config["APP_CONFIG"].demo_mode is False
+        assert Ticket.query.count() == 0
+        assert not (uploads_path / "demo").exists()
+
+    persisted = json.loads(config_path.read_text())
+    assert persisted["demo_mode"] is False

--- a/tickettracker/cli.py
+++ b/tickettracker/cli.py
@@ -1,0 +1,114 @@
+"""Command-line helpers for TicketTracker administration."""
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import replace
+from typing import Sequence
+
+from flask import current_app
+
+from .app import create_app
+from .config import AppConfig, save_config
+from .demo import DemoModeError, get_demo_manager
+
+
+def _persist_demo_flag(value: bool) -> AppConfig:
+    config: AppConfig = current_app.config["APP_CONFIG"]
+    if config.demo_mode == value:
+        return config
+
+    updated_config = replace(config, demo_mode=value)
+    try:
+        save_config(updated_config)
+    except ValueError as exc:
+        raise DemoModeError(
+            "Unable to persist configuration changes for demo mode."
+        ) from exc
+
+    current_app.config["APP_CONFIG"] = updated_config
+    current_app.config["DEMO_MODE"] = updated_config.demo_mode
+    return updated_config
+
+
+def _handle_demo_action(action: str) -> int:
+    manager = get_demo_manager(current_app)
+    config: AppConfig = current_app.config["APP_CONFIG"]
+
+    if action == "enable":
+        try:
+            manager.enable()
+        except DemoModeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        try:
+            config = _persist_demo_flag(True)
+        except DemoModeError as exc:
+            try:
+                manager.disable()
+            except DemoModeError:
+                pass
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        message = "Demo mode enabled. Sample dataset loaded and live data snapshotted."
+    elif action == "disable":
+        try:
+            manager.disable()
+        except DemoModeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        try:
+            config = _persist_demo_flag(False)
+        except DemoModeError as exc:
+            try:
+                manager.enable()
+            except DemoModeError:
+                pass
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        message = "Demo mode disabled. Original data restored."
+    elif action == "refresh":
+        try:
+            manager.refresh()
+        except DemoModeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        message = "Demo dataset refreshed."
+    else:
+        print(f"Unknown demo action: {action}", file=sys.stderr)
+        return 1
+
+    current_app.config["APP_CONFIG"] = config
+    print(message)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="tickettracker", description="TicketTracker utilities")
+    subparsers = parser.add_subparsers(dest="command")
+
+    demo_parser = subparsers.add_parser(
+        "demo", help="Manage demo mode and sample dataset"
+    )
+    demo_parser.add_argument(
+        "action", choices=("enable", "disable", "refresh"), help="Demo mode action to perform"
+    )
+    demo_parser.add_argument(
+        "--config",
+        dest="config_path",
+        help="Path to configuration file (defaults to standard lookup)",
+    )
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.command == "demo":
+        app = create_app(args.config_path)
+        with app.app_context():
+            return _handle_demo_action(args.action)
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/tickettracker/demo.py
+++ b/tickettracker/demo.py
@@ -1,0 +1,511 @@
+"""Demo data loading utilities and demo-mode orchestration."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from flask import Flask, current_app
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from .extensions import db
+from .migrations import run_migrations
+from .models import Attachment, Tag, Ticket, TicketTag, TicketUpdate
+
+
+class DemoModeError(RuntimeError):
+    """Raised when demo-mode operations encounter an unrecoverable error."""
+
+
+DATASET_FILENAME = "demo_tickets.json"
+STATE_FILENAME = "state.json"
+SNAPSHOT_DATABASE_FILENAME = "database.sqlite"
+SNAPSHOT_UPLOADS_DIRNAME = "uploads"
+
+
+@dataclass
+class DemoModeState:
+    """Persisted metadata tracking demo mode activity."""
+
+    active: bool = False
+    dataset_name: str = DATASET_FILENAME
+    database_uri: str | None = None
+    uploads_directory: str | None = None
+    last_loaded_at: str | None = None
+    had_database: bool = False
+    had_uploads: bool = False
+
+    @classmethod
+    def load(cls, directory: Path) -> "DemoModeState":
+        state_path = directory / STATE_FILENAME
+        if not state_path.exists():
+            return cls()
+        try:
+            payload = json.loads(state_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise DemoModeError(f"Invalid demo mode state metadata: {exc}") from exc
+
+        return cls(
+            active=bool(payload.get("active", False)),
+            dataset_name=str(payload.get("dataset_name", DATASET_FILENAME)),
+            database_uri=payload.get("database_uri"),
+            uploads_directory=payload.get("uploads_directory"),
+            last_loaded_at=payload.get("last_loaded_at"),
+            had_database=bool(payload.get("had_database", False)),
+            had_uploads=bool(payload.get("had_uploads", False)),
+        )
+
+    def save(self, directory: Path) -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "active": self.active,
+            "dataset_name": self.dataset_name,
+            "database_uri": self.database_uri,
+            "uploads_directory": self.uploads_directory,
+            "last_loaded_at": self.last_loaded_at,
+            "had_database": self.had_database,
+            "had_uploads": self.had_uploads,
+        }
+        (directory / STATE_FILENAME).write_text(
+            json.dumps(payload, indent=2), encoding="utf-8"
+        )
+
+
+def _ensure_app(app: Flask | None = None) -> Flask:
+    if app is not None:
+        return app
+    try:
+        return current_app  # type: ignore[misc]
+    except RuntimeError as exc:  # pragma: no cover - guard clause
+        raise DemoModeError("An application context is required for demo operations.") from exc
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    normalized = text.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise DemoModeError(f"Invalid datetime value in demo dataset: {value!r}") from exc
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+def _parse_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text)
+    except ValueError as exc:
+        raise DemoModeError(f"Invalid date value in demo dataset: {value!r}") from exc
+
+
+def _normalize_watchers(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw_entries = value.replace(";", ",").split(",")
+    elif isinstance(value, Iterable):
+        raw_entries = list(value)
+    else:
+        raw_entries = [value]
+
+    watchers: List[str] = []
+    seen: set[str] = set()
+    for entry in raw_entries:
+        text = str(entry or "").strip()
+        if not text or text in seen:
+            continue
+        watchers.append(text)
+        seen.add(text)
+    return watchers
+
+
+def _normalize_links(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    if isinstance(value, Iterable):
+        flattened: List[str] = []
+        for entry in value:
+            text = str(entry or "").strip()
+            if text:
+                flattened.append(text)
+        if not flattened:
+            return None
+        return "\n".join(flattened)
+    return str(value)
+
+
+def _write_attachment_file(
+    uploads_directory: Path, stored_filename: str, content: Optional[str] = None
+) -> Path:
+    normalized_name = stored_filename.replace("\\", "/").lstrip("/")
+    if not normalized_name:
+        raise DemoModeError("Attachment stored filename cannot be empty")
+    target_path = uploads_directory / normalized_name
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    if content is not None:
+        target_path.write_text(str(content), encoding="utf-8")
+    elif not target_path.exists():
+        target_path.write_text("Demo attachment placeholder", encoding="utf-8")
+    return target_path
+
+
+def load_demo_dataset(
+    dataset_path: os.PathLike[str] | str,
+    *,
+    session: Optional[Session] = None,
+    uploads_directory: os.PathLike[str] | str | None = None,
+    use_transaction: bool = True,
+) -> None:
+    """Load demo tickets, tags, and related data from ``dataset_path``."""
+
+    dataset = Path(dataset_path)
+    if not dataset.exists():
+        raise DemoModeError(f"Demo dataset not found: {dataset}")
+
+    data = json.loads(dataset.read_text(encoding="utf-8"))
+
+    raw_tags = data.get("tags", [])
+    raw_tickets = data.get("tickets", [])
+
+    session = session or db.session
+    uploads_path = Path(uploads_directory) if uploads_directory else Path(current_app.config["UPLOAD_FOLDER"])
+    uploads_path.mkdir(parents=True, exist_ok=True)
+
+    def _populate() -> None:
+        session.execute(delete(Attachment))
+        session.execute(delete(TicketUpdate))
+        session.execute(delete(TicketTag))
+        session.execute(delete(Ticket))
+        session.execute(delete(Tag))
+
+        tag_map: Dict[str, Tag] = {}
+        for tag_data in raw_tags:
+            if not isinstance(tag_data, Mapping):
+                continue
+            name = str(tag_data.get("name", "")).strip()
+            if not name:
+                continue
+            tag = Tag(name=name, color=tag_data.get("color"))
+            session.add(tag)
+            tag_map[name] = tag
+
+        session.flush()
+
+        for ticket_data in raw_tickets:
+            if not isinstance(ticket_data, Mapping):
+                continue
+            title = str(ticket_data.get("title", "")).strip()
+            description = str(ticket_data.get("description", "")).strip()
+            if not title or not description:
+                continue
+
+            ticket = Ticket(
+                title=title,
+                description=description,
+                requester=ticket_data.get("requester"),
+                priority=str(ticket_data.get("priority", "Medium") or "Medium"),
+                status=str(ticket_data.get("status", "Open") or "Open"),
+                due_date=_parse_datetime(ticket_data.get("due_date")),
+                notes=ticket_data.get("notes"),
+                links=_normalize_links(ticket_data.get("links")),
+                on_hold_reason=ticket_data.get("on_hold_reason"),
+                created_at=_parse_datetime(ticket_data.get("created_at")) or datetime.utcnow(),
+                updated_at=_parse_datetime(ticket_data.get("updated_at")) or datetime.utcnow(),
+                age_reference_date=_parse_date(ticket_data.get("age_reference_date")),
+            )
+
+            watchers = _normalize_watchers(ticket_data.get("watchers"))
+            if watchers:
+                ticket.watchers = watchers
+
+            session.add(ticket)
+            session.flush()
+
+            tag_names = [str(name) for name in ticket_data.get("tags", []) if str(name).strip()]
+            resolved_tags = [tag_map[name.strip()] for name in tag_names if name.strip() in tag_map]
+            if resolved_tags:
+                ticket.tags = resolved_tags
+
+            updates = ticket_data.get("updates", [])
+            for update_data in updates:
+                if not isinstance(update_data, Mapping):
+                    continue
+                update = TicketUpdate(
+                    ticket=ticket,
+                    body=str(update_data.get("body", "")).strip() or "Update",
+                    author=update_data.get("author"),
+                    created_at=_parse_datetime(update_data.get("created_at")) or datetime.utcnow(),
+                    status_from=update_data.get("status_from"),
+                    status_to=update_data.get("status_to"),
+                    is_system=bool(update_data.get("is_system", False)),
+                )
+                session.add(update)
+                session.flush()
+
+                attachments = update_data.get("attachments", [])
+                for attachment_data in attachments:
+                    if not isinstance(attachment_data, Mapping):
+                        continue
+                    stored_filename = str(attachment_data.get("stored_filename", "")).strip()
+                    if not stored_filename:
+                        continue
+                    content = attachment_data.get("content")
+                    file_path = _write_attachment_file(uploads_path, stored_filename, content)
+                    attachment = Attachment(
+                        ticket=ticket,
+                        update=update,
+                        original_filename=attachment_data.get("original_filename")
+                        or Path(stored_filename).name,
+                        stored_filename=stored_filename,
+                        mimetype=attachment_data.get("mimetype"),
+                        size=int(attachment_data.get("size" or 0) or file_path.stat().st_size),
+                        uploaded_at=_parse_datetime(attachment_data.get("uploaded_at"))
+                        or update.created_at,
+                    )
+                    session.add(attachment)
+
+            ticket_level_attachments = ticket_data.get("attachments", [])
+            for attachment_data in ticket_level_attachments:
+                if not isinstance(attachment_data, Mapping):
+                    continue
+                stored_filename = str(attachment_data.get("stored_filename", "")).strip()
+                if not stored_filename:
+                    continue
+                content = attachment_data.get("content")
+                file_path = _write_attachment_file(uploads_path, stored_filename, content)
+                attachment = Attachment(
+                    ticket=ticket,
+                    original_filename=attachment_data.get("original_filename")
+                    or Path(stored_filename).name,
+                    stored_filename=stored_filename,
+                    mimetype=attachment_data.get("mimetype"),
+                    size=int(attachment_data.get("size" or 0) or file_path.stat().st_size),
+                    uploaded_at=_parse_datetime(attachment_data.get("uploaded_at"))
+                    or ticket.created_at,
+                )
+                session.add(attachment)
+
+    if use_transaction:
+        with session.begin():
+            _populate()
+    else:
+        _populate()
+
+
+class DemoModeManager:
+    """Coordinate demo-mode lifecycle including dataset loading and restoration."""
+
+    def __init__(self, app: Flask):
+        self.app = app
+        self.snapshot_root = Path(app.instance_path) / "demo_snapshot"
+        self.state = DemoModeState.load(self.snapshot_root)
+        self.dataset_path = (
+            Path(app.root_path).resolve() / "demo_data" / self.state.dataset_name
+        )
+        self._last_loaded: datetime | None = (
+            _parse_datetime(self.state.last_loaded_at) if self.state.last_loaded_at else None
+        )
+
+    @property
+    def is_active(self) -> bool:
+        return self.state.active
+
+    @property
+    def last_loaded_at(self) -> datetime | None:
+        return self._last_loaded
+
+    def _dataset(self) -> Path:
+        dataset = self.dataset_path
+        if not dataset.exists():
+            raise DemoModeError(f"Demo dataset missing: {dataset}")
+        return dataset
+
+    def _uploads_path(self) -> Path:
+        return Path(self.app.config["UPLOAD_FOLDER"]).resolve()
+
+    def _database_path(self) -> Path:
+        uri = str(self.app.config.get("SQLALCHEMY_DATABASE_URI", ""))
+        if uri.endswith("/:memory:"):
+            raise DemoModeError("Demo mode does not support in-memory SQLite databases.")
+        if not uri.startswith("sqlite:///"):
+            raise DemoModeError("Demo mode currently supports only SQLite database URIs.")
+        raw_path = uri.replace("sqlite:///", "", 1)
+        db_path = Path(raw_path)
+        return db_path.resolve()
+
+    def _dispose_engine(self) -> None:
+        db.session.remove()
+        try:
+            engine = db.engine
+        except RuntimeError:
+            return
+        engine.dispose()
+
+    def _copy_database(self, source: Path, target: Path) -> None:
+        if source.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+
+    def _clear_uploads(self, path: Path) -> None:
+        if path.exists():
+            shutil.rmtree(path)
+        path.mkdir(parents=True, exist_ok=True)
+
+    def _ensure_snapshot(self) -> None:
+        if self.state.active:
+            # Snapshot already captured; nothing to do.
+            return
+        db_path = self._database_path()
+        uploads_path = self._uploads_path()
+        snapshot_db = self.snapshot_root / SNAPSHOT_DATABASE_FILENAME
+        snapshot_uploads = self.snapshot_root / SNAPSHOT_UPLOADS_DIRNAME
+
+        self.snapshot_root.mkdir(parents=True, exist_ok=True)
+        if snapshot_db.exists():
+            snapshot_db.unlink()
+        if snapshot_uploads.exists():
+            shutil.rmtree(snapshot_uploads)
+
+        self._dispose_engine()
+        self._copy_database(db_path, snapshot_db)
+        if uploads_path.exists():
+            shutil.copytree(uploads_path, snapshot_uploads)
+        else:
+            snapshot_uploads.mkdir(parents=True, exist_ok=True)
+
+        self.state.had_database = db_path.exists()
+        self.state.had_uploads = uploads_path.exists() and any(uploads_path.iterdir())
+        self.state.database_uri = str(self.app.config.get("SQLALCHEMY_DATABASE_URI"))
+        self.state.uploads_directory = str(uploads_path)
+
+    def _restore_snapshot(self) -> None:
+        db_path = self._database_path()
+        uploads_path = self._uploads_path()
+        snapshot_db = self.snapshot_root / SNAPSHOT_DATABASE_FILENAME
+        snapshot_uploads = self.snapshot_root / SNAPSHOT_UPLOADS_DIRNAME
+
+        self._dispose_engine()
+        if db_path.exists():
+            db_path.unlink()
+        if self.state.had_database and snapshot_db.exists():
+            self._copy_database(snapshot_db, db_path)
+        else:
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            db.create_all()
+            run_migrations()
+
+        self._clear_uploads(uploads_path)
+        if self.state.had_uploads and snapshot_uploads.exists():
+            shutil.copytree(snapshot_uploads, uploads_path, dirs_exist_ok=True)
+
+    def enable(self) -> None:
+        """Enable demo mode, snapshotting live data on first activation."""
+
+        dataset_path = self._dataset()
+        self._ensure_snapshot()
+
+        db_path = self._database_path()
+        uploads_path = self._uploads_path()
+
+        try:
+            self._dispose_engine()
+            if db_path.exists():
+                db_path.unlink()
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            db.create_all()
+            run_migrations()
+
+            self._clear_uploads(uploads_path)
+
+            load_demo_dataset(
+                dataset_path, session=db.session, uploads_directory=uploads_path
+            )
+        except DemoModeError:
+            self._restore_snapshot()
+            raise
+        except Exception as exc:  # pragma: no cover - defensive branch
+            self._restore_snapshot()
+            raise DemoModeError(f"Unexpected error enabling demo mode: {exc}") from exc
+
+        self.state.active = True
+        self.state.dataset_name = dataset_path.name
+        timestamp = datetime.utcnow().replace(tzinfo=timezone.utc)
+        self.state.last_loaded_at = timestamp.isoformat()
+        self._last_loaded = timestamp
+        self.dataset_path = dataset_path
+        self.state.save(self.snapshot_root)
+        self.app.config["DEMO_MODE"] = True
+
+    def disable(self) -> None:
+        """Disable demo mode and restore the original snapshot."""
+
+        if not self.state.active:
+            return
+
+        self._restore_snapshot()
+
+        self.state.active = False
+        self.state.last_loaded_at = None
+        self._last_loaded = None
+        self.state.save(self.snapshot_root)
+        self.app.config["DEMO_MODE"] = False
+
+        # Clean up snapshot artifacts so a future enable captures a fresh snapshot.
+        snapshot_db = self.snapshot_root / SNAPSHOT_DATABASE_FILENAME
+        snapshot_uploads = self.snapshot_root / SNAPSHOT_UPLOADS_DIRNAME
+        if snapshot_db.exists():
+            snapshot_db.unlink()
+        if snapshot_uploads.exists():
+            shutil.rmtree(snapshot_uploads)
+
+    def refresh(self) -> None:
+        """Reload the demo dataset, discarding any interim demo changes."""
+
+        if not self.state.active:
+            raise DemoModeError("Demo mode is not currently active; enable it first.")
+        self.enable()
+
+    def status(self) -> Dict[str, Any]:
+        """Return runtime status metadata for presentation layers."""
+
+        try:
+            dataset = str(self._dataset())
+        except DemoModeError:
+            dataset = str(self.dataset_path)
+        return {
+            "active": self.state.active,
+            "dataset": dataset,
+            "snapshot_root": str(self.snapshot_root),
+            "last_loaded_at": self._last_loaded,
+        }
+
+
+def get_demo_manager(app: Flask | None = None) -> DemoModeManager:
+    """Return (and cache) the :class:`DemoModeManager` for ``app``."""
+
+    flask_app = _ensure_app(app)
+    key = "tickettracker_demo_manager"
+    manager: DemoModeManager | None = flask_app.extensions.get(key)  # type: ignore[assignment]
+    if manager is None:
+        manager = DemoModeManager(flask_app)
+        flask_app.extensions[key] = manager
+    return manager
+

--- a/tickettracker/demo_data/demo_tickets.json
+++ b/tickettracker/demo_data/demo_tickets.json
@@ -1,0 +1,186 @@
+{
+  "metadata": {
+    "description": "Comprehensive demo dataset covering escalations, holds, resolutions, and backlog scenarios.",
+    "generated_at": "2024-03-01T12:00:00+00:00"
+  },
+  "tags": [
+    {"name": "Incident", "color": "#dc2626"},
+    {"name": "Billing", "color": "#1d4ed8"},
+    {"name": "Infrastructure", "color": "#0ea5e9"},
+    {"name": "Customer", "color": "#f97316"},
+    {"name": "Onboarding", "color": "#22c55e"},
+    {"name": "SLA", "color": "#7c3aed"}
+  ],
+  "tickets": [
+    {
+      "title": "Gateway outage affecting checkout",
+      "description": "Customers cannot complete purchases through the hosted checkout form. Monitoring detected sustained 5xx responses coming from the payment gateway. Incident channel engaged and communications sent to stakeholders.",
+      "requester": "Monique Wallace",
+      "watchers": ["Payments Squad", "Incident Commander"],
+      "priority": "Critical",
+      "status": "In Progress",
+      "due_date": "2024-01-10T09:30:00+00:00",
+      "notes": "Temporary fix deployed; monitoring latency spikes.",
+      "links": [
+        "https://status.example.com/incidents/checkout-gateway"
+      ],
+      "tags": ["Incident", "SLA", "Infrastructure"],
+      "created_at": "2024-01-08T13:15:00+00:00",
+      "updated_at": "2024-01-09T10:22:00+00:00",
+      "updates": [
+        {
+          "body": "Initial alert triggered when error budget consumed for gateway latency.",
+          "author": "Incident Bot",
+          "created_at": "2024-01-08T13:20:00+00:00",
+          "status_from": "Open",
+          "status_to": "Investigating",
+          "is_system": true
+        },
+        {
+          "body": "Failover to secondary region initiated to restore service.",
+          "author": "Nikhil Shah",
+          "created_at": "2024-01-08T13:45:00+00:00",
+          "status_from": "Investigating",
+          "status_to": "In Progress",
+          "attachments": [
+            {
+              "original_filename": "failover-plan.txt",
+              "stored_filename": "demo/failover-plan.txt",
+              "mimetype": "text/plain",
+              "size": 542,
+              "content": "Checklist of steps executed during failover."
+            }
+          ]
+        },
+        {
+          "body": "Gateway recovered but latency elevated; continuing to monitor.",
+          "author": "Nikhil Shah",
+          "created_at": "2024-01-09T09:10:00+00:00"
+        }
+      ],
+      "attachments": [
+        {
+          "original_filename": "error-spike.png",
+          "stored_filename": "demo/error-spike.png",
+          "mimetype": "image/png",
+          "size": 20480,
+          "content": "Binary image placeholder"
+        }
+      ]
+    },
+    {
+      "title": "Refund workflow paused for audit",
+      "description": "Finance requested a pause on refund processing while auditors review the workflow. Customers with pending refunds must be tracked manually until the audit completes.",
+      "requester": "Finance Operations",
+      "watchers": "auditors@example.com, finance-lead@example.com",
+      "priority": "High",
+      "status": "On Hold",
+      "due_date": "2024-01-20T12:00:00+00:00",
+      "on_hold_reason": "Pending scheduled work",
+      "tags": ["Billing", "Customer"],
+      "created_at": "2023-12-15T09:00:00+00:00",
+      "updates": [
+        {
+          "body": "Finance requested hold pending completion of compliance questionnaire.",
+          "author": "Jordan Evans",
+          "created_at": "2023-12-15T11:30:00+00:00",
+          "status_from": "In Progress",
+          "status_to": "On Hold"
+        },
+        {
+          "body": "Customer outreach list compiled for manual refund tracking.",
+          "author": "Jordan Evans",
+          "created_at": "2023-12-16T08:15:00+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Automated welcome email duplicates",
+      "description": "New customers are receiving the welcome email twice when signing up during peak hours. Investigation shows a race condition between CRM and marketing automation triggers.",
+      "requester": "CX Insights",
+      "priority": "Medium",
+      "status": "Resolved",
+      "due_date": "2024-02-01T17:00:00+00:00",
+      "tags": ["Onboarding", "Customer"],
+      "created_at": "2024-01-03T10:05:00+00:00",
+      "updates": [
+        {
+          "body": "Reproduced duplicate emails during traffic burst in staging.",
+          "author": "Priya Patel",
+          "created_at": "2024-01-03T14:42:00+00:00"
+        },
+        {
+          "body": "Disabled redundant trigger in CRM, monitoring queue length.",
+          "author": "Priya Patel",
+          "created_at": "2024-01-04T09:20:00+00:00",
+          "status_from": "In Progress",
+          "status_to": "Resolved",
+          "attachments": [
+            {
+              "original_filename": "trigger-diff.png",
+              "stored_filename": "demo/trigger-diff.png",
+              "mimetype": "image/png",
+              "size": 10312,
+              "content": "Annotated screenshot of CRM trigger configuration."
+            }
+          ]
+        }
+      ],
+      "attachments": [
+        {
+          "original_filename": "duplicate-report.csv",
+          "stored_filename": "demo/duplicate-report.csv",
+          "mimetype": "text/csv",
+          "size": 3187,
+          "content": "timestamp,email,count\n2024-01-03T09:00:00Z,test@example.com,2"
+        }
+      ]
+    },
+    {
+      "title": "Feature request: dark mode for admin dashboard",
+      "description": "Multiple admins requested a dark mode toggle for accessibility reasons. Gather requirements and provide design mocks for review.",
+      "requester": "Product Feedback",
+      "priority": "Low",
+      "status": "Open",
+      "tags": ["Customer"],
+      "age_reference_date": "2023-11-10",
+      "created_at": "2023-11-12T15:40:00+00:00",
+      "updates": [
+        {
+          "body": "Compiled examples from other dashboards to inform design direction.",
+          "author": "Alex Rivera",
+          "created_at": "2023-11-18T12:05:00+00:00"
+        }
+      ]
+    },
+    {
+      "title": "Legacy backup job cleanup",
+      "description": "Decommission backup job left over from the data center migration. Ensure snapshots are archived before removal.",
+      "requester": "Infrastructure",
+      "priority": "High",
+      "status": "Closed",
+      "notes": "Job retired after migration; audit trail saved to storage.",
+      "links": [
+        "https://docs.example.com/backup-cleanup",
+        "https://internal.example.com/task/123"
+      ],
+      "tags": ["Infrastructure", "SLA"],
+      "created_at": "2023-10-02T07:10:00+00:00",
+      "updated_at": "2023-10-05T16:30:00+00:00",
+      "updates": [
+        {
+          "body": "Archived final snapshot to cold storage.",
+          "author": "Morgan Reed",
+          "created_at": "2023-10-04T18:15:00+00:00"
+        },
+        {
+          "body": "Disabled legacy cron job and confirmed cleanup.",
+          "author": "Morgan Reed",
+          "created_at": "2023-10-05T16:30:00+00:00",
+          "status_from": "In Progress",
+          "status_to": "Closed"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a curated demo dataset and loader capable of seeding SQLAlchemy models with tags, updates, and attachments
- manage demo mode lifecycle with snapshotting, settings UI controls, and a CLI helper
- document the workflow and add automated tests covering enable, refresh, and disable flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9579f4f08832ca27f261e77a76510