### PR TITLE
Improve ticket title spacing

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -785,8 +785,16 @@ body.compact .filter-fields .filter-actions {
   align-items: flex-start;
 }
 
-.ticket-card .title-group h2 {
-  margin-bottom: 0.35rem;
+.ticket-card .title-group,
+.ticket-detail > header .title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.ticket-card .title-group h2,
+.ticket-detail > header .title-group h2 {
+  margin: 0;
 }
 
 .ticket-title {


### PR DESCRIPTION
## Summary
- introduce a shared vertical gap for ticket list and detail title groups
- reset title margins to rely on the consistent gap so wrapped badges keep separation

## Testing
- pytest
- ruff check . *(fails: existing E402 import-order violations in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68f9c64f4768832c99927dfa53207bc7