### PR TITLE
Add clipboard timestamps section to summaries and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ The gradient palette exposes five keys—`stage0`, `stage1`, `stage2`, `stage3`,
 
 You can provide a different configuration by setting `TICKETTRACKER_CONFIG` to an alternate JSON file path before starting the app.
 
+Clipboard exports are driven by the `clipboard_summary` section. Both `html_sections` and `text_sections` accept ordered lists of section names, allowing you to reorder or omit parts of the ticket summary. Available sections include:
+
+- `header` – Renders the ticket title as the clipboard heading.
+- `timestamps` – Shows when the ticket was created and last updated.
+- `meta` – Lists status, priority, due date, and SLA countdown details.
+- `people` – Summarises the requester and watchers.
+- `description` – Outputs the ticket description field.
+- `links` – Copies reference links supplied on the ticket.
+- `notes` – Copies the internal notes field.
+- `tags` – Lists tag names associated with the ticket.
+- `updates` – Includes the most recent ticket updates up to the configured limit.
+
+The `updates_limit` value controls how many timeline entries are included when the `updates` section is enabled. Leaving `text_sections` empty instructs the app to reuse the HTML section list for the plain-text export. Removing the `timestamps` section omits created/updated lines from the summaries.
+
 ### Running the development server
 ```bash
 flask --app tickettracker.app:create_app run --debug

--- a/config.json
+++ b/config.json
@@ -54,6 +54,7 @@
   "clipboard_summary": {
     "html_sections": [
       "header",
+      "timestamps",
       "meta",
       "people",
       "description",
@@ -64,6 +65,7 @@
     ],
     "text_sections": [
       "header",
+      "timestamps",
       "meta",
       "people",
       "description",

--- a/templates/partials/_clipboard_summary_macros.html
+++ b/templates/partials/_clipboard_summary_macros.html
@@ -1,0 +1,9 @@
+{% macro with_section(name, active_sections) -%}
+  {% if name in active_sections %}
+    {{ caller() }}
+  {% endif %}
+{%- endmacro %}
+
+{% macro format_timestamp(value) -%}
+  {{ value.strftime('%b %d, %Y %H:%M') if value else '—' }}
+{%- endmacro %}

--- a/templates/partials/ticket_clipboard_summary.html
+++ b/templates/partials/ticket_clipboard_summary.html
@@ -1,20 +1,25 @@
 <article class="ticket-clipboard-summary">
-  {% if 'header' in sections %}
+  {% from "partials/_clipboard_summary_macros.html" import with_section, format_timestamp %}
+
+  {% call with_section('header', sections) %}
     <header>
-      <h1>Ticket #{{ ticket.id }} · {{ ticket.title }}</h1>
+      <h1>{{ ticket.title }}</h1>
+    </header>
+  {% endcall %}
+
+  {% call with_section('timestamps', sections) %}
+    <section>
+      <h2>Timeline</h2>
       <p>
         <strong>Created:</strong>
-        {{ ticket.created_at.strftime('%b %d, %Y %H:%M') if ticket.created_at else '—' }}<br />
+        {{ format_timestamp(ticket.created_at) }}<br />
         <strong>Updated:</strong>
-        {{ ticket.updated_at.strftime('%b %d, %Y %H:%M') if ticket.updated_at else '—' }}
+        {{ format_timestamp(ticket.updated_at) }}
       </p>
-      {% if ticket_url %}
-        <p><strong>Link:</strong> <a href="{{ ticket_url }}">{{ ticket_url }}</a></p>
-      {% endif %}
-    </header>
-  {% endif %}
+    </section>
+  {% endcall %}
 
-  {% if 'meta' in sections %}
+  {% call with_section('meta', sections) %}
     <section>
       <h2>Details</h2>
       <ul>
@@ -26,75 +31,87 @@
         {% endif %}
       </ul>
     </section>
-  {% endif %}
+  {% endcall %}
 
-  {% if 'people' in sections and (ticket.requester or ticket.watchers) %}
-    <section>
-      <h2>People</h2>
-      <ul>
-        {% if ticket.requester %}
-          <li><strong>Requester:</strong> {{ ticket.requester }}</li>
-        {% endif %}
-        {% if ticket.watchers %}
-          <li><strong>Watchers:</strong> {{ ticket.watchers|join(', ') }}</li>
-        {% endif %}
-      </ul>
-    </section>
-  {% endif %}
+  {% call with_section('people', sections) %}
+    {% if ticket.requester or ticket.watchers %}
+      <section>
+        <h2>People</h2>
+        <ul>
+          {% if ticket.requester %}
+            <li><strong>Requester:</strong> {{ ticket.requester }}</li>
+          {% endif %}
+          {% if ticket.watchers %}
+            <li><strong>Watchers:</strong> {{ ticket.watchers|join(', ') }}</li>
+          {% endif %}
+        </ul>
+      </section>
+    {% endif %}
+  {% endcall %}
 
-  {% if 'description' in sections and ticket.description %}
-    <section>
-      <h2>Description</h2>
-      <p>{{ ticket.description|urlize|replace('\n', '<br />')|safe }}</p>
-    </section>
-  {% endif %}
+  {% call with_section('description', sections) %}
+    {% if ticket.description %}
+      <section>
+        <h2>Description</h2>
+        <p>{{ ticket.description|urlize|replace('\n', '<br />')|safe }}</p>
+      </section>
+    {% endif %}
+  {% endcall %}
 
-  {% if 'links' in sections and ticket.links %}
-    <section>
-      <h2>Links</h2>
-      <p>{{ ticket.links|urlize|replace('\n', '<br />')|safe }}</p>
-    </section>
-  {% endif %}
+  {% call with_section('links', sections) %}
+    {% if ticket.links %}
+      <section>
+        <h2>Links</h2>
+        <p>{{ ticket.links|urlize|replace('\n', '<br />')|safe }}</p>
+      </section>
+    {% endif %}
+  {% endcall %}
 
-  {% if 'notes' in sections and ticket.notes %}
-    <section>
-      <h2>Notes</h2>
-      <p>{{ ticket.notes|urlize|replace('\n', '<br />')|safe }}</p>
-    </section>
-  {% endif %}
+  {% call with_section('notes', sections) %}
+    {% if ticket.notes %}
+      <section>
+        <h2>Notes</h2>
+        <p>{{ ticket.notes|urlize|replace('\n', '<br />')|safe }}</p>
+      </section>
+    {% endif %}
+  {% endcall %}
 
-  {% if 'tags' in sections and ticket.tags %}
-    <section>
-      <h2>Tags</h2>
-      <ul>
-        {% for tag in ticket.tags %}
-          <li>{{ tag.name }}</li>
-        {% endfor %}
-      </ul>
-    </section>
-  {% endif %}
+  {% call with_section('tags', sections) %}
+    {% if ticket.tags %}
+      <section>
+        <h2>Tags</h2>
+        <ul>
+          {% for tag in ticket.tags %}
+            <li>{{ tag.name }}</li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+  {% endcall %}
 
-  {% if 'updates' in sections and updates %}
-    <section>
-      <h2>Recent Updates</h2>
-      <ol>
-        {% for update in updates %}
-          <li>
-            <p>
-              <strong>{{ update.created_at.strftime('%b %d, %Y %H:%M') }}</strong>
-              by
-              {{ 'System' if update.is_system else (update.author or config.default_submitted_by) }}
-            </p>
-            {% if update.status_from or update.status_to %}
+  {% call with_section('updates', sections) %}
+    {% if updates %}
+      <section>
+        <h2>Recent Updates</h2>
+        <ol>
+          {% for update in updates %}
+            <li>
               <p>
-                <strong>Status:</strong>
-                {{ update.status_from or '—' }} → {{ update.status_to or '—' }}
+                <strong>{{ format_timestamp(update.created_at) }}</strong>
+                by
+                {{ 'System' if update.is_system else (update.author or config.default_submitted_by) }}
               </p>
-            {% endif %}
-            <p>{{ update.body|urlize|replace('\n', '<br />')|safe }}</p>
-          </li>
-        {% endfor %}
-      </ol>
-    </section>
-  {% endif %}
+              {% if update.status_from or update.status_to %}
+                <p>
+                  <strong>Status:</strong>
+                  {{ update.status_from or '—' }} → {{ update.status_to or '—' }}
+                </p>
+              {% endif %}
+              <p>{{ update.body|urlize|replace('\n', '<br />')|safe }}</p>
+            </li>
+          {% endfor %}
+        </ol>
+      </section>
+    {% endif %}
+  {% endcall %}
 </article>

--- a/templates/partials/ticket_clipboard_summary.txt
+++ b/templates/partials/ticket_clipboard_summary.txt
@@ -1,9 +1,11 @@
+{% from "partials/_clipboard_summary_macros.html" import format_timestamp %}
 {% if 'header' in sections %}
-Ticket #{{ ticket.id }} · {{ ticket.title }}
-Created: {{ ticket.created_at.strftime('%b %d, %Y %H:%M') if ticket.created_at else '—' }}
-Updated: {{ ticket.updated_at.strftime('%b %d, %Y %H:%M') if ticket.updated_at else '—' }}
-{% if ticket_url %}Link: {{ ticket_url }}
+{{ ticket.title }}
+
 {% endif %}
+{% if 'timestamps' in sections %}
+Created: {{ format_timestamp(ticket.created_at) }}
+Updated: {{ format_timestamp(ticket.updated_at) }}
 
 {% endif %}
 {% if 'meta' in sections %}
@@ -45,7 +47,7 @@ Tags: {{ ticket.tags|map(attribute='name')|join(', ') }}
 {% endif %}
 {% if 'updates' in sections and updates %}
 Recent Updates:
-{% for update in updates %}- {{ update.created_at.strftime('%b %d, %Y %H:%M') }} by {{ 'System' if update.is_system else (update.author or config.default_submitted_by) }}
+{% for update in updates %}- {{ format_timestamp(update.created_at) }} by {{ 'System' if update.is_system else (update.author or config.default_submitted_by) }}
 {% if update.status_from or update.status_to %}  Status: {{ update.status_from or '—' }} → {{ update.status_to or '—' }}
 {% endif %}{% for line in update.body.splitlines() %}
   {{ line }}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -68,7 +68,15 @@
           name="html_sections"
           rows="4"
         >{{- form.html_sections|default('') -}}</textarea>
-        <p class="help">Customize the sections used when generating HTML clipboard summaries.</p>
+        <p class="help">
+          List clipboard section names one per line to control HTML clipboard exports.
+          Available sections:
+        </p>
+        <ul class="help-list">
+          {% for section, description in clipboard_sections.items() %}
+            <li><code>{{ section }}</code> — {{ description }}</li>
+          {% endfor %}
+        </ul>
       </div>
 
       <div class="field-group">
@@ -78,7 +86,10 @@
           name="text_sections"
           rows="4"
         >{{- form.text_sections|default('') -}}</textarea>
-        <p class="help">Leave blank to reuse the HTML section list for plain text summaries.</p>
+        <p class="help">
+          Leave blank to reuse the HTML section list for plain text summaries. Include
+          <code>timestamps</code> to copy created/updated times or remove it to omit them.
+        </p>
       </div>
 
       <div class="field-group">

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -35,6 +35,8 @@ def test_load_config_records_source_path(tmp_path):
     payload = config.to_json_dict()
     assert payload["demo_mode"] is False
     assert payload["database"]["uri"].endswith("/:memory:")
+    assert payload["clipboard_summary"]["html_sections"][1] == "timestamps"
+    assert payload["clipboard_summary"]["text_sections"][1] == "timestamps"
 
 
 def test_settings_update_persists_between_app_starts(tmp_path):
@@ -55,8 +57,8 @@ def test_settings_update_persists_between_app_starts(tmp_path):
             "priorities": "Low\nMedium\nHigh\nUrgent",
             "hold_reasons": "Awaiting info\nReview pending",
             "workflow": "New\nActive\nDone",
-            "html_sections": "header\nsummary",
-            "text_sections": "header\nsummary\nnotes",
+            "html_sections": "header\ntimestamps\nsummary",
+            "text_sections": "header\ntimestamps\nsummary\nnotes",
             "updates_limit": "3",
             "demo_mode": "on",
         },
@@ -70,9 +72,14 @@ def test_settings_update_persists_between_app_starts(tmp_path):
     assert persisted["priorities"] == ["Low", "Medium", "High", "Urgent"]
     assert persisted["hold_reasons"] == ["Awaiting info", "Review pending"]
     assert persisted["workflow"] == ["New", "Active", "Done"]
-    assert persisted["clipboard_summary"]["html_sections"] == ["header", "summary"]
+    assert persisted["clipboard_summary"]["html_sections"] == [
+        "header",
+        "timestamps",
+        "summary",
+    ]
     assert persisted["clipboard_summary"]["text_sections"] == [
         "header",
+        "timestamps",
         "summary",
         "notes",
     ]
@@ -93,10 +100,12 @@ def test_settings_update_persists_between_app_starts(tmp_path):
         assert reloaded_config.hold_reasons == ["Awaiting info", "Review pending"]
         assert reloaded_config.clipboard_summary.html_sections == [
             "header",
+            "timestamps",
             "summary",
         ]
         assert reloaded_config.clipboard_summary.text_sections == [
             "header",
+            "timestamps",
             "summary",
             "notes",
         ]

--- a/tickettracker/config.py
+++ b/tickettracker/config.py
@@ -39,6 +39,7 @@ DEFAULT_BACKLOG_DUE_DAYS = 21
 
 DEFAULT_CLIPBOARD_SUMMARY_SECTIONS: List[str] = [
     "header",
+    "timestamps",
     "meta",
     "people",
     "description",
@@ -205,13 +206,15 @@ class ClipboardSummaryConfig:
     updates_limit: int = DEFAULT_CLIPBOARD_SUMMARY["updates_limit"]
 
     def sections_for_html(self) -> List[str]:
-        if self.html_sections:
-            return list(self.html_sections)
+        sections = list(self.html_sections)
+        if sections:
+            return sections
         return list(DEFAULT_CLIPBOARD_SUMMARY["html_sections"])
 
     def sections_for_text(self) -> List[str]:
-        if self.text_sections:
-            return list(self.text_sections)
+        sections = list(self.text_sections)
+        if sections:
+            return sections
         if self.html_sections:
             return list(self.html_sections)
         return list(DEFAULT_CLIPBOARD_SUMMARY["text_sections"])
@@ -219,12 +222,29 @@ class ClipboardSummaryConfig:
     def max_updates(self) -> int:
         return max(0, int(self.updates_limit))
 
+    def available_sections(self) -> List[str]:
+        """Return a unique list of known clipboard sections."""
+
+        seen: set[str] = set()
+        ordered: List[str] = []
+        for value in [
+            *DEFAULT_CLIPBOARD_SUMMARY_SECTIONS,
+            *self.html_sections,
+            *self.text_sections,
+        ]:
+            key = str(value or "").strip().lower()
+            if not key or key in seen:
+                continue
+            ordered.append(key)
+            seen.add(key)
+        return ordered
+
     def to_dict(self) -> Dict[str, Any]:
         """Return a JSON-serializable representation of clipboard options."""
 
         return {
-            "html_sections": list(self.html_sections),
-            "text_sections": list(self.text_sections),
+            "html_sections": self.sections_for_html(),
+            "text_sections": self.sections_for_text(),
             "updates_limit": int(self.updates_limit),
         }
 

--- a/tickettracker/views/settings.py
+++ b/tickettracker/views/settings.py
@@ -16,6 +16,7 @@ from flask import (
 
 from ..config import AppConfig, save_config
 from ..demo import DemoModeError, get_demo_manager
+from ..summary import CLIPBOARD_SUMMARY_SECTION_DESCRIPTIONS
 
 
 settings_bp = Blueprint("settings", __name__)
@@ -246,6 +247,7 @@ def view_settings():
         compact_toggle_url=_build_compact_toggle_url(
             "settings.view_settings", compact_mode
         ),
+        clipboard_sections=CLIPBOARD_SUMMARY_SECTION_DESCRIPTIONS,
     )
 
 


### PR DESCRIPTION
## Summary
- add the new `timestamps` entry to the default clipboard configuration and expose helper metadata for templates
- refresh the clipboard summary templates to use macros, remove inline links, and support toggling timestamps in both HTML and text outputs
- improve settings guidance, documentation, and tests so the timestamps section is persisted and described to operators

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9c49400e8832c8e7105fd5874653a