### PR TITLE
Add collapsible attachment controls to ticket forms

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -252,6 +252,19 @@ body.compact .filter-collapsible {
   border-radius: 0.9rem;
 }
 
+body.compact .attachment-collapsible {
+  padding: 0.75rem 0.95rem;
+}
+
+body.compact .attachment-icon {
+  width: 1.75rem;
+  height: 1.75rem;
+}
+
+body.compact .attachment-summary-count {
+  font-size: 0.75rem;
+}
+
 body.compact .filter-fields {
   gap: 0.75rem;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -593,6 +606,115 @@ body.compact .filter-fields .filter-actions {
   color: var(--accent);
   font-size: 0.75rem;
   line-height: 1;
+}
+
+.attachment-collapsible {
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 1rem;
+  padding: 0.9rem 1.1rem;
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.attachment-collapsible > summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: rgba(148, 163, 184, 0.85);
+  transition: color 0.2s ease;
+}
+
+.attachment-collapsible > summary::-webkit-details-marker {
+  display: none;
+}
+
+.attachment-collapsible > summary:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.6);
+  outline-offset: 4px;
+  border-radius: 0.75rem;
+}
+
+.attachment-collapsible > summary:hover {
+  color: #f8fafc;
+}
+
+.attachment-collapsible[open] > summary,
+.attachment-collapsible[data-has-files='true'] > summary {
+  color: #f8fafc;
+}
+
+.attachment-collapsible[open] {
+  border-color: rgba(56, 189, 248, 0.4);
+  box-shadow: 0 12px 32px rgba(2, 6, 23, 0.35);
+}
+
+.attachment-collapsible[data-has-files='true'] {
+  border-color: rgba(56, 189, 248, 0.35);
+}
+
+.attachment-toggle-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.attachment-toggle-state--open {
+  display: none;
+}
+
+.attachment-collapsible[open] .attachment-toggle-state--closed {
+  display: none;
+}
+
+.attachment-collapsible[open] .attachment-toggle-state--open {
+  display: inline;
+}
+
+.attachment-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.75rem;
+  background: rgba(56, 189, 248, 0.12);
+  color: rgba(56, 189, 248, 0.85);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.attachment-icon svg {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.attachment-summary-count {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.attachment-collapsible[data-has-files='true'] .attachment-summary-count {
+  color: var(--accent);
+  font-weight: 500;
+}
+
+.attachment-fields {
+  margin-top: 1.1rem;
+}
+
+.attachment-fields .help {
+  margin: 0;
+}
+
+.help {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
 }
 
 .sr-only {

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -243,11 +243,44 @@
         {% endfor %}
       </select>
     </div>
-    <div class="field-group">
-      <label for="attachments">Attachments</label>
-      <input type="file" id="attachments" name="attachments" multiple />
-      <p class="help">Files are stored locally inside <code>{{ app_config.uploads_path }}</code>.</p>
-    </div>
+    <details class="attachment-collapsible" data-attachment-collapsible>
+      <summary class="attachment-toggle">
+        <span class="attachment-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <path
+              d="M16.5 6.5v8a4.5 4.5 0 1 1-9 0V5a3.5 3.5 0 0 1 7 0v9a2.5 2.5 0 1 1-5 0V6.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.7"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            ></path>
+          </svg>
+        </span>
+        <span class="attachment-toggle-text">
+          <span class="attachment-toggle-state attachment-toggle-state--closed">Add attachments</span>
+          <span class="attachment-toggle-state attachment-toggle-state--open">Hide attachments</span>
+        </span>
+        <span class="attachment-summary-count" data-attachment-count aria-live="polite" hidden></span>
+      </summary>
+      <div class="attachment-fields">
+        <div class="field-group">
+          <label for="attachments">Attachments</label>
+          <input
+            type="file"
+            id="attachments"
+            name="attachments"
+            multiple
+            aria-describedby="update-attachments-help"
+            data-attachment-input
+          />
+          <p class="help" id="update-attachments-help">
+            Files upload to <code>{{ app_config.uploads_path }}</code> when you submit this update.
+            Select as many files as you need in a single step.
+          </p>
+        </div>
+      </div>
+    </details>
     <div class="actions">
       <button type="submit" class="button primary">Add update</button>
       {% if not ticket.due_date %}
@@ -274,6 +307,39 @@
     updateStatusSelect.addEventListener('change', updateToggleHold);
     updateToggleHold();
   }
+
+  const formatAttachmentCount = (count) => `${count} file${count === 1 ? '' : 's'} selected`;
+  const attachmentDetails = document.querySelectorAll('[data-attachment-collapsible]');
+  attachmentDetails.forEach((details) => {
+    const input = details.querySelector('[data-attachment-input]');
+    const count = details.querySelector('[data-attachment-count]');
+
+    if (!input) return;
+
+    const updateAttachmentState = () => {
+      const files = input.files ? input.files.length : 0;
+      if (files > 0) {
+        details.dataset.hasFiles = 'true';
+        if (count) {
+          count.hidden = false;
+          count.textContent = formatAttachmentCount(files);
+        }
+        if (!details.open) {
+          details.open = true;
+        }
+      } else {
+        delete details.dataset.hasFiles;
+        if (count) {
+          count.hidden = true;
+          count.textContent = '';
+        }
+      }
+    };
+
+    input.addEventListener('change', updateAttachmentState);
+    input.addEventListener('input', updateAttachmentState);
+    updateAttachmentState();
+  });
 </script>
 {% endblock %}
 

--- a/templates/ticket_form.html
+++ b/templates/ticket_form.html
@@ -77,11 +77,44 @@
       <label for="notes">Private notes</label>
       <textarea id="notes" name="notes" rows="3">{{ ticket.notes if ticket else '' }}</textarea>
     </div>
-    <div class="field-group">
-      <label for="attachments">Attachments</label>
-      <input type="file" id="attachments" name="attachments" multiple />
-      <p class="help">Files upload into <code>{{ app_config.uploads_path }}</code>. Existing attachments stay unchanged.</p>
-    </div>
+    <details class="attachment-collapsible" data-attachment-collapsible>
+      <summary class="attachment-toggle">
+        <span class="attachment-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <path
+              d="M16.5 6.5v8a4.5 4.5 0 1 1-9 0V5a3.5 3.5 0 0 1 7 0v9a2.5 2.5 0 1 1-5 0V6.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.7"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            ></path>
+          </svg>
+        </span>
+        <span class="attachment-toggle-text">
+          <span class="attachment-toggle-state attachment-toggle-state--closed">Add attachments</span>
+          <span class="attachment-toggle-state attachment-toggle-state--open">Hide attachments</span>
+        </span>
+        <span class="attachment-summary-count" data-attachment-count aria-live="polite" hidden></span>
+      </summary>
+      <div class="attachment-fields">
+        <div class="field-group">
+          <label for="attachments">Attachments</label>
+          <input
+            type="file"
+            id="attachments"
+            name="attachments"
+            multiple
+            aria-describedby="ticket-attachments-help"
+            data-attachment-input
+          />
+          <p class="help" id="ticket-attachments-help">
+            Selected files upload to <code>{{ app_config.uploads_path }}</code> when you save.
+            Existing attachments stay unchanged, and you can choose multiple files at once.
+          </p>
+        </div>
+      </div>
+    </details>
     <div class="actions">
       <button type="submit" class="button primary">Save</button>
       <a class="button" href="{{ url_for('tickets.list_tickets', compact=compact_value) }}">Cancel</a>
@@ -103,5 +136,38 @@
     statusSelect.addEventListener('change', toggleHold);
     toggleHold();
   }
+
+  const formatAttachmentCount = (count) => `${count} file${count === 1 ? '' : 's'} selected`;
+  const attachmentDetails = document.querySelectorAll('[data-attachment-collapsible]');
+  attachmentDetails.forEach((details) => {
+    const input = details.querySelector('[data-attachment-input]');
+    const count = details.querySelector('[data-attachment-count]');
+
+    if (!input) return;
+
+    const updateAttachmentState = () => {
+      const files = input.files ? input.files.length : 0;
+      if (files > 0) {
+        details.dataset.hasFiles = 'true';
+        if (count) {
+          count.hidden = false;
+          count.textContent = formatAttachmentCount(files);
+        }
+        if (!details.open) {
+          details.open = true;
+        }
+      } else {
+        delete details.dataset.hasFiles;
+        if (count) {
+          count.hidden = true;
+          count.textContent = '';
+        }
+      }
+    };
+
+    input.addEventListener('change', updateAttachmentState);
+    input.addEventListener('input', updateAttachmentState);
+    updateAttachmentState();
+  });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace the attachments field groups in the ticket form and update form with a details-based paperclip toggle
- style the attachment collapsible to mirror the existing filter interaction and update the help copy about upload storage
- add lightweight JavaScript to auto-open the section and surface the selected file count while keeping multiple upload support

## Testing
- pytest
- python -m compileall tickettracker

------
https://chatgpt.com/codex/tasks/task_e_68f9cb58fde4832c948aa246b2a88371