### PR TITLE
Add quick attachment shortcut to ticket detail header

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -957,6 +957,37 @@ body.compact .filter-fields .filter-actions {
   gap: 0.75rem;
 }
 
+.ticket-action-buttons {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
+}
+
+.ticket-action-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.ticket-action-buttons .icon-button:not(.clipboard-button) {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--text-muted);
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.ticket-action-buttons .icon-button:not(.clipboard-button):hover,
+.ticket-action-buttons .icon-button:not(.clipboard-button):focus-visible {
+  color: #f8fafc;
+  border-color: rgba(56, 189, 248, 0.6);
+  background: rgba(56, 189, 248, 0.22);
+  transform: translateY(-1px);
+  text-decoration: none;
+}
+
 .clipboard-control {
   display: flex;
   flex-direction: column;
@@ -1410,6 +1441,18 @@ body.compact .filter-fields .filter-actions {
 
   .ticket-card .timestamps,
   .ticket-detail .timestamps {
+    text-align: left;
+  }
+
+  .ticket-detail .ticket-action-buttons {
+    align-items: flex-start;
+  }
+
+  .ticket-detail .ticket-action-bar {
+    justify-content: flex-start;
+  }
+
+  .ticket-detail .ticket-action-buttons .clipboard-status {
     text-align: left;
   }
 }

--- a/static/js/ticket_detail.js
+++ b/static/js/ticket_detail.js
@@ -1,0 +1,52 @@
+const quickAttachTrigger = document.querySelector('[data-quick-attachment-trigger]');
+const quickAttachInput = document.querySelector('[data-quick-attachment-input]');
+const autoAttachmentFlag = document.querySelector('[data-auto-attachment-flag]');
+
+if (quickAttachTrigger && quickAttachInput) {
+  const updateForm = quickAttachInput.closest('form');
+
+  if (updateForm) {
+    const resetFlag = () => {
+      if (autoAttachmentFlag) {
+        autoAttachmentFlag.value = '0';
+      }
+    };
+
+    const hasFilesSelected = () =>
+      Boolean(quickAttachInput.files && quickAttachInput.files.length > 0);
+
+    const submitForm = () => {
+      if (typeof updateForm.requestSubmit === 'function') {
+        updateForm.requestSubmit();
+      } else {
+        updateForm.submit();
+      }
+    };
+
+    quickAttachTrigger.addEventListener('click', (event) => {
+      event.preventDefault();
+      resetFlag();
+      quickAttachInput.value = '';
+      quickAttachInput.click();
+    });
+
+    quickAttachInput.addEventListener('change', () => {
+      if (hasFilesSelected()) {
+        if (autoAttachmentFlag) {
+          autoAttachmentFlag.value = '1';
+        }
+        submitForm();
+      } else {
+        resetFlag();
+      }
+    });
+
+    quickAttachInput.addEventListener('input', () => {
+      if (!hasFilesSelected()) {
+        resetFlag();
+      }
+    });
+
+    quickAttachInput.addEventListener('cancel', resetFlag);
+  }
+}

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -54,24 +54,62 @@
         <span>Created {{ ticket.created_at.strftime('%b %d, %Y %H:%M') }}</span>
         <span>Updated {{ ticket.updated_at.strftime('%b %d, %Y %H:%M') }}</span>
       </div>
-      <div class="clipboard-control">
-        <button
-          type="button"
-          class="icon-button clipboard-button"
-          data-clipboard-button
-          aria-describedby="clipboard-status-{{ ticket.id }}"
-          title="Copy ticket summary"
-        >
-          <span class="icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
-              <path
-                d="M16 3H5a2 2 0 0 0-2 2v11h2V5h11V3zm3 4H9a2 2 0 0 0-2 2v12h12a2 2 0 0 0 2-2V7z"
-                fill="currentColor"
-              ></path>
-            </svg>
-          </span>
-          <span class="sr-only">Copy summary</span>
-        </button>
+      <div class="ticket-action-buttons">
+        <div class="ticket-action-bar">
+          <button
+            type="button"
+            class="icon-button clipboard-button"
+            data-clipboard-button
+            aria-describedby="clipboard-status-{{ ticket.id }}"
+            title="Copy ticket summary"
+          >
+            <span class="icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                <path
+                  d="M16 3H5a2 2 0 0 0-2 2v11h2V5h11V3zm3 4H9a2 2 0 0 0-2 2v12h12a2 2 0 0 0 2-2V7z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="sr-only">Copy summary</span>
+          </button>
+          <button
+            type="button"
+            class="icon-button quick-attach-button"
+            data-quick-attachment-trigger
+            aria-controls="quick-attachment-input"
+            title="Quick attach files"
+          >
+            <span class="icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                <path
+                  d="M16.5 6.5v8a4.5 4.5 0 1 1-9 0V5a3.5 3.5 0 0 1 7 0v9a2.5 2.5 0 1 1-5 0V6.5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                ></path>
+              </svg>
+            </span>
+            <span class="sr-only">Quick attach files</span>
+          </button>
+          <a
+            class="icon-button edit-ticket-button"
+            href="{{ url_for('tickets.edit_ticket', ticket_id=ticket.id, compact=compact_value) }}"
+            title="Edit ticket"
+          >
+            <span class="icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                <path
+                  d="M4 16.75V20h3.25L17.81 9.44l-3.25-3.25L4 16.75zm15.71-9.04a1.004 1.004 0 0 0 0-1.42l-2-2a1.004 1.004 0 0 0-1.42 0l-1.83 1.83 3.25 3.25 2-1.66z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="sr-only">Edit ticket</span>
+          </a>
+        </div>
         <span
           class="clipboard-status"
           id="clipboard-status-{{ ticket.id }}"
@@ -126,14 +164,6 @@
           </div>
         {% endif %}
       </dl>
-      <div class="actions">
-        <a
-          class="button"
-          href="{{ url_for('tickets.edit_ticket', ticket_id=ticket.id, compact=compact_value) }}"
-        >
-          Edit ticket
-        </a>
-      </div>
     </aside>
   </section>
 
@@ -210,6 +240,22 @@
     enctype="multipart/form-data"
     class="update-form"
   >
+    <input
+      type="hidden"
+      name="auto_attachment"
+      value="0"
+      data-auto-attachment-flag
+    />
+    <input
+      type="file"
+      id="quick-attachment-input"
+      name="attachments"
+      multiple
+      hidden
+      data-quick-attachment-input
+      aria-hidden="true"
+      tabindex="-1"
+    />
     <div class="field-group">
       <label for="message">Message</label>
       <textarea id="message" name="message" rows="4" placeholder="Share progress, blockers, or notes"></textarea>
@@ -346,4 +392,5 @@
 {% block scripts %}
   {{ super() }}
   <script type="module" src="{{ url_for('static', filename='js/clipboard.js') }}"></script>
+  <script type="module" src="{{ url_for('static', filename='js/ticket_detail.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- group ticket detail header actions with copy, quick attach, and edit controls while wiring a hidden attachment input and flag into the update form
- add a ticket detail script that routes quick-attach clicks to the hidden input and auto-submits the form when files are chosen
- extend styles to support the new action cluster layout and responsive alignment

## Testing
- pytest
- python -m compileall tickettracker

------
https://chatgpt.com/codex/tasks/task_e_68f9d6db68a8832c817e75a7ded07348