### PR TITLE
Update ticket detail form controls

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -855,6 +855,38 @@ body.compact .filter-fields .filter-actions {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
+.update-form .form-controls-row {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
+}
+
+.update-form .form-controls-row > * {
+  min-width: 0;
+}
+
+.update-form .form-controls-row .form-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  align-self: end;
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.9);
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.update-form .form-controls-row .form-checkbox input {
+  width: 1rem;
+  height: 1rem;
+}
+
+.update-form .form-controls-row .button {
+  align-self: end;
+  justify-self: end;
+}
+
 .field-group[data-hidden] {
   display: none;
 }

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -203,7 +203,7 @@
           <div class="timeline-content">
             <div class="update-meta">
               <span class="author">
-                Submitted By:
+                Attribute To:
                 {{ 'System' if update.is_system else (update.author or config.default_submitted_by) }}
               </span>
               <span class="timestamp">{{ update.created_at.strftime('%b %d, %Y %H:%M') }}</span>
@@ -260,18 +260,18 @@
       <label for="message">Message</label>
       <textarea id="message" name="message" rows="4" placeholder="Share progress, blockers, or notes"></textarea>
     </div>
-    <div class="field-group split">
-      <div>
-        <label for="submitted_by">Submitted By</label>
+    <div class="form-controls-row">
+      <div class="field-group">
+        <label for="submitted_by">Attribute To</label>
         <input
           type="text"
           id="submitted_by"
           name="submitted_by"
-          placeholder="Submitted By (defaults to {{ config.default_submitted_by }})"
+          placeholder="Attribute To (defaults to {{ config.default_submitted_by }})"
           value="{{ config.default_submitted_by }}"
         />
       </div>
-      <div>
+      <div class="field-group">
         <label for="status">Status</label>
         <select id="status" name="status">
           {% for status in config.workflow %}
@@ -279,8 +279,19 @@
           {% endfor %}
         </select>
       </div>
+      {% if not ticket.due_date %}
+        <label class="form-checkbox" for="reage_ticket">
+          <input type="checkbox" id="reage_ticket" name="reage_ticket" value="1" />
+          Re-age ticket
+        </label>
+      {% endif %}
+      <button type="submit" class="button primary">Add update</button>
     </div>
-    <div class="field-group" {% if ticket.status != 'On Hold' %}data-hidden{% endif %}>
+    <div
+      class="field-group"
+      data-on-hold-group
+      {% if ticket.status != 'On Hold' %}data-hidden{% endif %}
+    >
       <label for="on_hold_reason">On hold reason</label>
       <select id="on_hold_reason" name="on_hold_reason">
         <option value="">Select reason</option>
@@ -289,58 +300,11 @@
         {% endfor %}
       </select>
     </div>
-    <details class="attachment-collapsible" data-attachment-collapsible>
-      <summary class="attachment-toggle">
-        <span class="attachment-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
-            <path
-              d="M16.5 6.5v8a4.5 4.5 0 1 1-9 0V5a3.5 3.5 0 0 1 7 0v9a2.5 2.5 0 1 1-5 0V6.5"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.7"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-          </svg>
-        </span>
-        <span class="attachment-toggle-text">
-          <span class="attachment-toggle-state attachment-toggle-state--closed">Add attachments</span>
-          <span class="attachment-toggle-state attachment-toggle-state--open">Hide attachments</span>
-        </span>
-        <span class="attachment-summary-count" data-attachment-count aria-live="polite" hidden></span>
-      </summary>
-      <div class="attachment-fields">
-        <div class="field-group">
-          <label for="attachments">Attachments</label>
-          <input
-            type="file"
-            id="attachments"
-            name="attachments"
-            multiple
-            aria-describedby="update-attachments-help"
-            data-attachment-input
-          />
-          <p class="help" id="update-attachments-help">
-            Files upload to <code>{{ app_config.uploads_path }}</code> when you submit this update.
-            Select as many files as you need in a single step.
-          </p>
-        </div>
-      </div>
-    </details>
-    <div class="actions">
-      <button type="submit" class="button primary">Add update</button>
-      {% if not ticket.due_date %}
-        <label class="checkbox" for="reage_ticket">
-          <input type="checkbox" id="reage_ticket" name="reage_ticket" value="1" />
-          Re-age ticket
-        </label>
-      {% endif %}
-    </div>
   </form>
 </section>
 <script>
   const updateStatusSelect = document.getElementById('status');
-  const updateHoldGroup = document.querySelector('.update-form [data-hidden]');
+  const updateHoldGroup = document.querySelector('[data-on-hold-group]');
   const updateToggleHold = () => {
     if (!updateHoldGroup) return;
     if (updateStatusSelect && updateStatusSelect.value === 'On Hold') {
@@ -353,39 +317,6 @@
     updateStatusSelect.addEventListener('change', updateToggleHold);
     updateToggleHold();
   }
-
-  const formatAttachmentCount = (count) => `${count} file${count === 1 ? '' : 's'} selected`;
-  const attachmentDetails = document.querySelectorAll('[data-attachment-collapsible]');
-  attachmentDetails.forEach((details) => {
-    const input = details.querySelector('[data-attachment-input]');
-    const count = details.querySelector('[data-attachment-count]');
-
-    if (!input) return;
-
-    const updateAttachmentState = () => {
-      const files = input.files ? input.files.length : 0;
-      if (files > 0) {
-        details.dataset.hasFiles = 'true';
-        if (count) {
-          count.hidden = false;
-          count.textContent = formatAttachmentCount(files);
-        }
-        if (!details.open) {
-          details.open = true;
-        }
-      } else {
-        delete details.dataset.hasFiles;
-        if (count) {
-          count.hidden = true;
-          count.textContent = '';
-        }
-      }
-    };
-
-    input.addEventListener('change', updateAttachmentState);
-    input.addEventListener('input', updateAttachmentState);
-    updateAttachmentState();
-  });
 </script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- rename the ticket update attribution copy to use "Attribute To"
- reorganize the add-update form controls into a single responsive row and remove the collapsible attachment helper
- simplify the inline script now that the quick attach flow manages uploads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9f73fbd5c832c9eb16837fbc19f1f