### PR TITLE
Style ticket detail tag and attachment panels

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -374,6 +374,20 @@ body.compact .ticket-detail {
   margin-bottom: 1.75rem;
 }
 
+body.compact .ticket-detail .tag-list,
+body.compact .ticket-detail .attachments {
+  padding: 1.2rem 1.35rem;
+  border-radius: 1.25rem;
+  margin: 1.5rem 0;
+  box-shadow: 0 16px 36px rgba(2, 6, 23, 0.32);
+}
+
+body.compact .ticket-detail .tag-list h3,
+body.compact .ticket-detail .attachments h3 {
+  margin-bottom: 0.75rem;
+  font-size: 0.95rem;
+}
+
 body.compact .detail-grid {
   gap: 1.5rem;
 }
@@ -1329,6 +1343,25 @@ body.compact .filter-fields .filter-actions {
   margin-bottom: 2rem;
 }
 
+.ticket-detail .tag-list,
+.ticket-detail .attachments {
+  position: relative;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 1.5rem;
+  padding: 1.5rem 1.75rem;
+  margin: 2rem 0;
+  box-shadow: 0 20px 45px rgba(2, 6, 23, 0.35);
+  overflow: hidden;
+}
+
+.ticket-detail .tag-list h3,
+.ticket-detail .attachments h3 {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  color: #f8fafc;
+}
+
 .detail-grid {
   margin-top: 1.75rem;
   display: grid;
@@ -1473,6 +1506,13 @@ body.compact .filter-fields .filter-actions {
 
   .ticket-detail {
     padding: 1.5rem;
+  }
+
+  .ticket-detail .tag-list,
+  .ticket-detail .attachments {
+    padding: 1.35rem 1.25rem;
+    border-radius: 1.35rem;
+    margin: 1.75rem 0;
   }
 
   .detail-grid {


### PR DESCRIPTION
## Summary
- add panel-style backgrounds, padding, and spacing to the ticket detail tag list and attachments sections
- tune compact mode and breakpoint styling so the new buffer scales without overflow
- adjust heading spacing to preserve breathing room around the lists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9f99a0330832c889432bef7515b87