### PR TITLE
Restyle clipboard ticket summary

### DIFF
--- a/templates/partials/ticket_clipboard_summary.html
+++ b/templates/partials/ticket_clipboard_summary.html
@@ -1,90 +1,354 @@
 {% from "partials/_clipboard_summary_macros.html" import with_section, format_timestamp %}
 {% set use_inline_styles = config.clipboard_summary.inline_styles %}
-{% set article_style = "font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; background-color: #ffffff; border: 1px solid #d1d5db; border-radius: 8px; padding: 16px; color: #0f172a; line-height: 1.5; width: 100%; box-sizing: border-box;" if use_inline_styles else "" %}
-{% set header_style = "margin: 0 0 12px 0; padding-bottom: 8px; border-bottom: 1px solid #e2e8f0;" if use_inline_styles else "" %}
-{% set title_style = "margin: 0; font-size: 20px; line-height: 1.4; color: #111827;" if use_inline_styles else "" %}
-{% set section_style = "margin-top: 16px;" if use_inline_styles else "" %}
-{% set section_heading_style = "margin: 0 0 8px 0; font-size: 13px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: #475569;" if use_inline_styles else "" %}
-{% set paragraph_style = "margin: 0; color: #0f172a;" if use_inline_styles else "" %}
-{% set inline_hint_style = "margin-left: 8px; color: #475569; font-weight: 500;" if use_inline_styles else "" %}
-{% set table_style = "width: 100%; border-collapse: collapse; margin: 0;" if use_inline_styles else "" %}
-{% set th_style = "padding: 4px 0; text-align: left; font-weight: 600; color: #1e293b; vertical-align: top; width: 32%;" if use_inline_styles else "" %}
-{% set td_style = "padding: 4px 0; color: #0f172a; vertical-align: top;" if use_inline_styles else "" %}
-{% set badge_style = "display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 12px; font-weight: 600; line-height: 1.4; color: #ffffff;" if use_inline_styles else "" %}
-{% set due_badge_style = "display: inline-block; padding: 2px 8px; border-radius: 6px; font-size: 12px; font-weight: 600; line-height: 1.4; color: #0f172a;" if use_inline_styles else "" %}
-{% set tag_list_style = "margin: 0; padding: 0; list-style: none;" if use_inline_styles else "" %}
-{% set tag_item_style = "display: inline-block; margin: 0 8px 8px 0;" if use_inline_styles else "" %}
-{% set tag_badge_style = "display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 12px; font-weight: 500;" if use_inline_styles else "" %}
-{% set update_list_style = "margin: 0; padding-left: 18px;" if use_inline_styles else "" %}
-{% set update_item_base_style = "margin: 0; padding: 12px 0;" if use_inline_styles else "" %}
-{% set update_meta_style = "margin: 0 0 4px 0; color: #0f172a; font-weight: 600;" if use_inline_styles else "" %}
-{% set update_meta_detail_style = "margin-left: 8px; color: #475569; font-weight: 500;" if use_inline_styles else "" %}
-{% set update_body_style = "margin: 0 0 4px 0; color: #0f172a;" if use_inline_styles else "" %}
-{% set update_body_last_style = "margin: 0; color: #0f172a;" if use_inline_styles else "" %}
-{% set status_badge_style = badge_style + ' background-color: ' + (ticket.status_color or '#3b82f6') + ';' if badge_style else '' %}
+{% set include_header = 'header' in sections %}
+{% set include_timestamps = 'timestamps' in sections %}
+{% set accent_color = ticket.display_color or '#38bdf8' %}
+{% set tint_color = ticket.tint_color or 'rgba(56, 189, 248, 0.22)' %}
+{% set title_color = ticket_title_color|default('#f8fafc') %}
+{% set status_color = ticket.status_color or accent_color %}
 {% set priority_color = config.colors.priorities.get(ticket.priority, '#3b82f6') %}
-{% set priority_badge_style = badge_style + ' background-color: ' + priority_color + ';' if badge_style else '' %}
 {% set due_color = ticket.due_badge_color or '#e2e8f0' %}
-{% set due_badge_style_value = due_badge_style + ' background-color: ' + due_color + ';' if due_badge_style else '' %}
+{% set muted_color = 'rgba(148, 163, 184, 0.85)' %}
+{% set text_color = '#e2e8f0' %}
 {% set tag_text_color = config.colors.tags.get('text', '#f8fafc') %}
+{% set article_properties = [
+  '--ticket-accent: ' ~ accent_color,
+  '--ticket-tint: ' ~ tint_color,
+  '--ticket-title-color: ' ~ title_color,
+  '--ticket-status-color: ' ~ status_color,
+  '--ticket-priority-color: ' ~ priority_color,
+  '--ticket-due-color: ' ~ due_color,
+] %}
+{% set article_style_parts = article_properties + ([
+  "font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif",
+  "background: linear-gradient(155deg, " ~ tint_color ~ " 0%, rgba(17, 24, 39, 0.92) 52%, rgba(15, 23, 42, 0.82) 100%)",
+  "color: " ~ text_color,
+  "border-radius: 28px",
+  "border: 1px solid rgba(148, 163, 184, 0.18)",
+  "padding: 32px",
+  "box-sizing: border-box",
+  "width: 100%",
+  "line-height: 1.6",
+  "background-clip: padding-box",
+] if use_inline_styles else []) %}
+{% set article_style = article_style_parts | join('; ') %}
+{% set header_style = "display: flex; justify-content: space-between; gap: 24px; align-items: flex-start; margin-bottom: 28px;" if use_inline_styles else "" %}
+{% set title_group_style = "display: flex; flex-direction: column; gap: 12px;" if use_inline_styles else "" %}
+{% set title_style = "margin: 0; font-size: 28px; line-height: 1.2; color: " ~ title_color ~ ";" if use_inline_styles else "" %}
+{% set timestamps_style = "display: flex; flex-direction: column; gap: 6px; font-size: 13px; color: " ~ muted_color ~ "; text-align: right;" if use_inline_styles else "" %}
+{% set section_style = "margin-top: 28px;" if use_inline_styles else "" %}
+{% set section_heading_style = "margin: 0 0 12px 0; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; color: " ~ muted_color ~ ";" if use_inline_styles else "" %}
+{% set paragraph_style = "margin: 0; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
+{% set table_style = "width: 100%; border-collapse: collapse;" if use_inline_styles else "" %}
+{% set th_style = "padding: 6px 0; width: 32%; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: " ~ muted_color ~ "; vertical-align: top;" if use_inline_styles else "" %}
+{% set td_style = "padding: 6px 0; color: " ~ text_color ~ "; vertical-align: top;" if use_inline_styles else "" %}
+{% set badge_base_style = "display: inline-flex; align-items: center; justify-content: center; padding: 4px 12px; border-radius: 999px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; white-space: nowrap; box-shadow: 0 6px 18px rgba(2, 6, 23, 0.35); border: 1px solid rgba(148, 163, 184, 0.35);" if use_inline_styles else "" %}
+{% set status_badge_style = badge_base_style + " background: " + status_color + "; color: #f8fafc;" if badge_base_style else "" %}
+{% set priority_badge_style = badge_base_style + " background: " + priority_color + "; color: #0f172a; box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.35), 0 8px 16px rgba(2, 6, 23, 0.35);" if badge_base_style else "" %}
+{% set due_badge_style_value = badge_base_style + " background: " + due_color + "; color: #f8fafc;" if badge_base_style else "" %}
+{% set sla_badge_style = badge_base_style + " background: rgba(56, 189, 248, 0.35); color: #f8fafc;" if badge_base_style else "" %}
+{% set status_note_style = "margin-left: 8px; font-size: 12px; color: " ~ muted_color ~ "; letter-spacing: 0.03em;" if use_inline_styles else "" %}
+{% set inline_hint_style = "margin-left: 8px; font-size: 12px; color: " ~ muted_color ~ "; letter-spacing: 0.03em;" if use_inline_styles else "" %}
+{% set tag_list_style = "list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 8px;" if use_inline_styles else "" %}
+{% set tag_badge_base_style = "display: inline-flex; align-items: center; padding: 6px 12px; border-radius: 999px; font-size: 12px; letter-spacing: 0.03em;" if use_inline_styles else "" %}
+{% set timeline_style = "list-style: none; margin: 24px 0 0; padding: 0 0 0 20px; border-left: 2px solid rgba(148, 163, 184, 0.2); display: grid; gap: 24px;" if use_inline_styles else "" %}
+{% set timeline_item_style = "position: relative; padding-left: 24px;" if use_inline_styles else "" %}
+{% set timeline_marker_style = "position: absolute; left: -12px; top: 8px; width: 10px; height: 10px; border-radius: 50%; background: " ~ accent_color ~ "; box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.12);" if use_inline_styles else "" %}
+{% set timeline_content_style = "background: rgba(15, 23, 42, 0.65); border: 1px solid rgba(148, 163, 184, 0.18); border-radius: 16px; padding: 16px; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
+{% set timeline_meta_style = "display: flex; flex-wrap: wrap; gap: 8px 16px; font-size: 13px; color: " ~ muted_color ~ "; margin: 0 0 8px;" if use_inline_styles else "" %}
+{% set timeline_body_style = "margin: 0 0 8px 0; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
+{% set timeline_body_last_style = "margin: 0; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
+{% if not use_inline_styles %}
+<style>
+  .ticket-clipboard-summary {
+    font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+    background: linear-gradient(
+      155deg,
+      var(--ticket-tint, rgba(56, 189, 248, 0.22)) 0%,
+      rgba(17, 24, 39, 0.92) 52%,
+      rgba(15, 23, 42, 0.82) 100%
+    );
+    color: #e2e8f0;
+    border-radius: 1.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    padding: 2rem;
+    box-sizing: border-box;
+    width: 100%;
+    line-height: 1.6;
+    background-clip: padding-box;
+  }
+
+  .ticket-clipboard-summary * {
+    box-sizing: border-box;
+  }
+
+  .ticket-clipboard-summary a {
+    color: var(--ticket-accent, #38bdf8);
+  }
+
+  .ticket-clipboard-summary header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1.5rem;
+    align-items: flex-start;
+    margin-bottom: 1.75rem;
+  }
+
+  .ticket-clipboard-summary .summary-title-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .ticket-clipboard-summary .summary-title {
+    margin: 0;
+    font-size: 1.75rem;
+    line-height: 1.2;
+    color: var(--ticket-title-color, #f8fafc);
+  }
+
+  .ticket-clipboard-summary .summary-timestamps {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    color: rgba(148, 163, 184, 0.9);
+    text-align: right;
+  }
+
+  .ticket-clipboard-summary .summary-section {
+    margin-top: 1.75rem;
+  }
+
+  .ticket-clipboard-summary .summary-section h2 {
+    margin: 0 0 0.75rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.95);
+  }
+
+  .ticket-clipboard-summary .summary-section p {
+    margin: 0;
+    color: #e2e8f0;
+  }
+
+  .ticket-clipboard-summary .summary-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .ticket-clipboard-summary .summary-table th {
+    padding: 0.35rem 0;
+    width: 32%;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: rgba(148, 163, 184, 0.85);
+    vertical-align: top;
+  }
+
+  .ticket-clipboard-summary .summary-table td {
+    padding: 0.35rem 0;
+    color: #f8fafc;
+    vertical-align: top;
+  }
+
+  .ticket-clipboard-summary .summary-table tr + tr td,
+  .ticket-clipboard-summary .summary-table tr + tr th {
+    border-top: 1px solid rgba(148, 163, 184, 0.16);
+  }
+
+  .ticket-clipboard-summary .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    white-space: nowrap;
+    box-shadow: 0 6px 18px rgba(2, 6, 23, 0.35);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+  }
+
+  .ticket-clipboard-summary .status-badge {
+    background: var(--ticket-status-color, rgba(148, 163, 184, 0.28));
+    color: #f8fafc;
+  }
+
+  .ticket-clipboard-summary .priority-badge {
+    background: var(--ticket-priority-color, rgba(148, 163, 184, 0.25));
+    color: #0f172a;
+    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.35), 0 8px 16px rgba(2, 6, 23, 0.35);
+  }
+
+  .ticket-clipboard-summary .due-badge {
+    background: var(--ticket-due-color, rgba(56, 189, 248, 0.35));
+    color: #f8fafc;
+  }
+
+  .ticket-clipboard-summary .sla-badge {
+    background: rgba(56, 189, 248, 0.35);
+    color: #f8fafc;
+  }
+
+  .ticket-clipboard-summary .status-note,
+  .ticket-clipboard-summary .age-badge {
+    font-size: 0.75rem;
+    color: rgba(148, 163, 184, 0.85);
+    letter-spacing: 0.03em;
+  }
+
+  .ticket-clipboard-summary .status-note::before {
+    content: "·";
+    margin: 0 0.35rem;
+    color: rgba(148, 163, 184, 0.7);
+  }
+
+  .ticket-clipboard-summary .summary-tags {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+  }
+
+  .ticket-clipboard-summary .summary-tags li {
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    letter-spacing: 0.03em;
+    background: var(--tag-color, rgba(30, 41, 59, 0.85));
+    color: var(--tag-text, #f8fafc);
+  }
+
+  .ticket-clipboard-summary .summary-timeline {
+    list-style: none;
+    margin: 1.5rem 0 0;
+    padding: 0 0 0 1.25rem;
+    border-left: 2px solid rgba(148, 163, 184, 0.2);
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .ticket-clipboard-summary .summary-timeline li {
+    position: relative;
+    padding-left: 1.5rem;
+  }
+
+  .ticket-clipboard-summary .timeline-marker {
+    position: absolute;
+    left: -1.25rem;
+    top: 0.5rem;
+    width: 0.65rem;
+    height: 0.65rem;
+    border-radius: 50%;
+    background: var(--ticket-accent, #38bdf8);
+    box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.12);
+  }
+
+  .ticket-clipboard-summary .timeline-content {
+    background: rgba(15, 23, 42, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 1rem;
+    padding: 1rem;
+    color: #e2e8f0;
+  }
+
+  .ticket-clipboard-summary .timeline-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    font-size: 0.8rem;
+    color: rgba(148, 163, 184, 0.85);
+    margin-bottom: 0.5rem;
+  }
+
+  .ticket-clipboard-summary .timeline-body {
+    margin: 0;
+    color: #f8fafc;
+  }
+
+  .ticket-clipboard-summary .timeline-body strong {
+    color: #f8fafc;
+  }
+</style>
+{% endif %}
 <article class="ticket-clipboard-summary" data-clipboard-summary="ticket"{% if article_style %} style="{{ article_style }}"{% endif %}>
   {% call with_section('header', sections) %}
-    <header data-clipboard-section="header"{% if header_style %} style="{{ header_style }}"{% endif %}>
-      <h1{% if title_style %} style="{{ title_style }}"{% endif %}>{{ ticket.title }}</h1>
+    <header class="summary-header" data-clipboard-section="header"{% if header_style %} style="{{ header_style }}"{% endif %}>
+      <div class="summary-title-group"{% if title_group_style %} style="{{ title_group_style }}"{% endif %}>
+        <h1 class="summary-title"{% if title_style %} style="{{ title_style }}"{% endif %}>{{ ticket.title }}</h1>
+      </div>
+      {% if include_timestamps %}
+        <div class="summary-timestamps"{% if timestamps_style %} style="{{ timestamps_style }}"{% endif %}>
+          <span>Created {{ format_timestamp(ticket.created_at) }}</span>
+          <span>Updated {{ format_timestamp(ticket.updated_at) }}</span>
+        </div>
+      {% endif %}
     </header>
   {% endcall %}
 
-  {% call with_section('timestamps', sections) %}
-    <section data-clipboard-section="timestamps"{% if section_style %} style="{{ section_style }}"{% endif %}>
-      <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>Timeline</h2>
-      <table{% if table_style %} style="{{ table_style }}"{% endif %}>
-        <tbody>
-          <tr>
-            <th{% if th_style %} style="{{ th_style }}"{% endif %}>Created</th>
-            <td{% if td_style %} style="{{ td_style }}"{% endif %}>{{ format_timestamp(ticket.created_at) }}</td>
-          </tr>
-          <tr>
-            <th{% if th_style %} style="{{ th_style }}"{% endif %}>Updated</th>
-            <td{% if td_style %} style="{{ td_style }}"{% endif %}>{{ format_timestamp(ticket.updated_at) }}</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-  {% endcall %}
+  {% if include_timestamps and not include_header %}
+    {% call with_section('timestamps', sections) %}
+      <section class="summary-section" data-clipboard-section="timestamps"{% if section_style %} style="{{ section_style }}"{% endif %}>
+        <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>Timeline</h2>
+        <table class="summary-table"{% if table_style %} style="{{ table_style }}"{% endif %}>
+          <tbody>
+            <tr>
+              <th{% if th_style %} style="{{ th_style }}"{% endif %}>Created</th>
+              <td{% if td_style %} style="{{ td_style }}"{% endif %}>{{ format_timestamp(ticket.created_at) }}</td>
+            </tr>
+            <tr>
+              <th{% if th_style %} style="{{ th_style }}"{% endif %}>Updated</th>
+              <td{% if td_style %} style="{{ td_style }}"{% endif %}>{{ format_timestamp(ticket.updated_at) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    {% endcall %}
+  {% endif %}
 
   {% call with_section('meta', sections) %}
-    <section data-clipboard-section="meta"{% if section_style %} style="{{ section_style }}"{% endif %}>
+    <section class="summary-section" data-clipboard-section="meta"{% if section_style %} style="{{ section_style }}"{% endif %}>
       <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>Details</h2>
-      <table{% if table_style %} style="{{ table_style }}"{% endif %}>
+      <table class="summary-table"{% if table_style %} style="{{ table_style }}"{% endif %}>
         <tbody>
           <tr>
             <th{% if th_style %} style="{{ th_style }}"{% endif %}>Status</th>
             <td{% if td_style %} style="{{ td_style }}"{% endif %}>
-              <span{% if status_badge_style %} style="{{ status_badge_style }}"{% endif %}>{{ ticket.status }}</span>
+              <span class="badge status-badge"{% if status_badge_style %} style="{{ status_badge_style }}"{% endif %}>{{ ticket.status }}</span>
               {% if ticket.status == 'On Hold' and ticket.on_hold_reason %}
-                <span{% if inline_hint_style %} style="{{ inline_hint_style }}"{% endif %}>{{ ticket.on_hold_reason }}</span>
+                {% set hold_prefix = '• ' if use_inline_styles else '' %}
+                <span class="status-note"{% if status_note_style %} style="{{ status_note_style }}"{% endif %}>{{ hold_prefix }}{{ ticket.on_hold_reason }}</span>
               {% endif %}
             </td>
           </tr>
           <tr>
             <th{% if th_style %} style="{{ th_style }}"{% endif %}>Priority</th>
             <td{% if td_style %} style="{{ td_style }}"{% endif %}>
-              <span{% if priority_badge_style %} style="{{ priority_badge_style }}"{% endif %}>{{ ticket.priority }}</span>
+              <span class="badge priority-badge"{% if priority_badge_style %} style="{{ priority_badge_style }}"{% endif %}>{{ ticket.priority }}</span>
             </td>
           </tr>
           <tr>
             <th{% if th_style %} style="{{ th_style }}"{% endif %}>Due</th>
             <td{% if td_style %} style="{{ td_style }}"{% endif %}>
-              <span{% if due_badge_style_value %} style="{{ due_badge_style_value }}"{% endif %}>{{ ticket.due_badge_label }}</span>
+              <span class="badge due-badge"{% if due_badge_style_value %} style="{{ due_badge_style_value }}"{% endif %}>{{ ticket.due_badge_label }}</span>
               {% if not ticket.due_date and ticket.age_reference_date %}
-                <span{% if inline_hint_style %} style="{{ inline_hint_style }}"{% endif %}>Aging since {{ ticket.age_reference_date.strftime('%b %d, %Y') }}</span>
+                <span class="age-badge"{% if inline_hint_style %} style="{{ inline_hint_style }}"{% endif %}>Aging since {{ ticket.age_reference_date.strftime('%b %d, %Y') }}</span>
               {% endif %}
             </td>
           </tr>
           {% if ticket.sla_countdown %}
             <tr>
               <th{% if th_style %} style="{{ th_style }}"{% endif %}>SLA</th>
-              <td{% if td_style %} style="{{ td_style }}"{% endif %}>{{ ticket.sla_countdown }}</td>
+              <td{% if td_style %} style="{{ td_style }}"{% endif %}>
+                <span class="badge sla-badge"{% if sla_badge_style %} style="{{ sla_badge_style }}"{% endif %}>{{ ticket.sla_countdown }}</span>
+              </td>
             </tr>
           {% endif %}
         </tbody>
@@ -94,9 +358,9 @@
 
   {% call with_section('people', sections) %}
     {% if ticket.requester or ticket.watchers %}
-      <section data-clipboard-section="people"{% if section_style %} style="{{ section_style }}"{% endif %}>
+      <section class="summary-section" data-clipboard-section="people"{% if section_style %} style="{{ section_style }}"{% endif %}>
         <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>People</h2>
-        <table{% if table_style %} style="{{ table_style }}"{% endif %}>
+        <table class="summary-table"{% if table_style %} style="{{ table_style }}"{% endif %}>
           <tbody>
             {% if ticket.requester %}
               <tr>
@@ -118,7 +382,7 @@
 
   {% call with_section('description', sections) %}
     {% if ticket.description %}
-      <section data-clipboard-section="description"{% if section_style %} style="{{ section_style }}"{% endif %}>
+      <section class="summary-section" data-clipboard-section="description"{% if section_style %} style="{{ section_style }}"{% endif %}>
         <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>Description</h2>
         <p{% if paragraph_style %} style="{{ paragraph_style }}"{% endif %}>{{ ticket.description|urlize|replace('\n', '<br />')|safe }}</p>
       </section>
@@ -127,7 +391,7 @@
 
   {% call with_section('links', sections) %}
     {% if ticket.links %}
-      <section data-clipboard-section="links"{% if section_style %} style="{{ section_style }}"{% endif %}>
+      <section class="summary-section" data-clipboard-section="links"{% if section_style %} style="{{ section_style }}"{% endif %}>
         <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>Links</h2>
         <p{% if paragraph_style %} style="{{ paragraph_style }}"{% endif %}>{{ ticket.links|urlize|replace('\n', '<br />')|safe }}</p>
       </section>
@@ -136,7 +400,7 @@
 
   {% call with_section('notes', sections) %}
     {% if ticket.notes %}
-      <section data-clipboard-section="notes"{% if section_style %} style="{{ section_style }}"{% endif %}>
+      <section class="summary-section" data-clipboard-section="notes"{% if section_style %} style="{{ section_style }}"{% endif %}>
         <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>Notes</h2>
         <p{% if paragraph_style %} style="{{ paragraph_style }}"{% endif %}>{{ ticket.notes|urlize|replace('\n', '<br />')|safe }}</p>
       </section>
@@ -145,14 +409,15 @@
 
   {% call with_section('tags', sections) %}
     {% if ticket.tags %}
-      <section data-clipboard-section="tags"{% if section_style %} style="{{ section_style }}"{% endif %}>
+      <section class="summary-section" data-clipboard-section="tags"{% if section_style %} style="{{ section_style }}"{% endif %}>
         <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>Tags</h2>
-        <ul{% if tag_list_style %} style="{{ tag_list_style }}"{% endif %}>
+        <ul class="summary-tags"{% if tag_list_style %} style="{{ tag_list_style }}"{% endif %}>
           {% for tag in ticket.tags %}
             {% set tag_background = tag.color or config.colors.tags.get('background', '#1e293b') %}
-            {% set tag_style_value = tag_badge_style + ' background-color: ' + tag_background + '; color: ' + tag_text_color + ';' if tag_badge_style else '' %}
-            <li{% if tag_item_style %} style="{{ tag_item_style }}"{% endif %}>
-              <span{% if tag_style_value %} style="{{ tag_style_value }}"{% endif %}>{{ tag.name }}</span>
+            {% set tag_variable_style = '--tag-color: ' ~ tag_background ~ '; --tag-text: ' ~ tag_text_color ~ ';' %}
+            {% set tag_style_value = tag_variable_style + (' ' + tag_badge_base_style + ' background: ' + tag_background + '; color: ' + tag_text_color + ';' if tag_badge_base_style else '') %}
+            <li style="{{ tag_style_value }}">
+              {{ tag.name }}
             </li>
           {% endfor %}
         </ul>
@@ -162,34 +427,31 @@
 
   {% call with_section('updates', sections) %}
     {% if updates %}
-      <section data-clipboard-section="updates"{% if section_style %} style="{{ section_style }}"{% endif %}>
+      <section class="summary-section" data-clipboard-section="updates"{% if section_style %} style="{{ section_style }}"{% endif %}>
         <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>Recent Updates</h2>
-        <ol{% if update_list_style %} style="{{ update_list_style }}"{% endif %}>
+        <ol class="summary-timeline"{% if timeline_style %} style="{{ timeline_style }}"{% endif %}>
           {% for update in updates %}
-            {% set item_style = update_item_base_style %}
-            {% if use_inline_styles %}
-              {% if loop.first %}
-                {% set item_style = item_style + ' margin-top: 0;' %}
-              {% else %}
-                {% set item_style = item_style + ' border-top: 1px solid #e2e8f0;' %}
-              {% endif %}
-              {% if not loop.last %}
-                {% set item_style = item_style + ' margin-bottom: 12px;' %}
-              {% endif %}
-            {% endif %}
-            <li{% if item_style %} style="{{ item_style }}"{% endif %}>
-              <p{% if update_meta_style %} style="{{ update_meta_style }}"{% endif %}>
-                <strong>{{ format_timestamp(update.created_at) }}</strong>
-                {% set author = 'System' if update.is_system else (update.author or config.default_submitted_by) %}
-                <span{% if update_meta_detail_style %} style="{{ update_meta_detail_style }}"{% endif %}>by {{ author }}</span>
-              </p>
-              {% if update.status_from or update.status_to %}
-                <p{% if update_body_style %} style="{{ update_body_style }}"{% endif %}>
-                  <strong>Status:</strong>
-                  {{ update.status_from or '—' }} → {{ update.status_to or '—' }}
+            <li{% if timeline_item_style %} style="{{ timeline_item_style }}"{% endif %}>
+              <span class="timeline-marker" aria-hidden="true"{% if timeline_marker_style %} style="{{ timeline_marker_style }}"{% endif %}></span>
+              <div class="timeline-content"{% if timeline_content_style %} style="{{ timeline_content_style }}"{% endif %}>
+                <p class="timeline-meta"{% if timeline_meta_style %} style="{{ timeline_meta_style }}"{% endif %}>
+                  <span>{{ format_timestamp(update.created_at) }}</span>
+                  {% set author = 'System' if update.is_system else (update.author or config.default_submitted_by) %}
+                  <span>by {{ author }}</span>
                 </p>
-              {% endif %}
-              <p{% if update_body_last_style %} style="{{ update_body_last_style }}"{% endif %}>{{ update.body|urlize|replace('\n', '<br />')|safe }}</p>
+                {% if update.status_from or update.status_to %}
+                  <p class="timeline-body"{% if timeline_body_style %} style="{{ timeline_body_style }}"{% endif %}>
+                    <strong>Status:</strong>
+                    {{ update.status_from or '—' }} → {{ update.status_to or '—' }}
+                  </p>
+                {% endif %}
+                {% if loop.last %}
+                  {% set update_body_style = timeline_body_last_style %}
+                {% else %}
+                  {% set update_body_style = timeline_body_style %}
+                {% endif %}
+                <p class="timeline-body"{% if update_body_style %} style="{{ update_body_style }}"{% endif %}>{{ update.body|urlize|replace('\n', '<br />')|safe }}</p>
+              </div>
             </li>
           {% endfor %}
         </ol>


### PR DESCRIPTION
## Summary
- add scoped clipboard summary styles that mirror the ticket detail gradient and typography while supporting inline overrides
- restructure the HTML markup so badges, sections, and tags share the ticket-detail layout and variables
- refresh the updates list into a styled timeline with markers and preserved inline-style compatibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9f9b29a3c832cab9ec8f863647e5d