### PR TITLE
Link tag pills to filtered ticket view

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -358,7 +358,7 @@ body.compact .tags {
   gap: 0.4rem;
 }
 
-body.compact .tags li {
+body.compact .tags li .tag-link {
   padding: 0.3rem 0.55rem;
   font-size: 0.7rem;
 }
@@ -1279,12 +1279,46 @@ body.compact .filter-fields .filter-actions {
 }
 
 .tags li {
-  background: var(--tag-color, rgba(30, 41, 59, 0.8));
-  color: var(--tag-text, var(--text));
+  --tag-surface: var(--tag-color, rgba(30, 41, 59, 0.8));
+  --tag-foreground: var(--tag-text, var(--text));
+}
+
+.tags li .tag-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--tag-surface);
+  color: var(--tag-foreground);
   padding: 0.35rem 0.65rem;
   border-radius: 999px;
   font-size: 0.75rem;
   letter-spacing: 0.03em;
+  line-height: 1;
+  text-decoration: none;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.35);
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease,
+    transform 0.15s ease;
+}
+
+.tags li .tag-link:visited {
+  color: var(--tag-foreground);
+}
+
+.tags li .tag-link:hover,
+.tags li .tag-link:focus-visible {
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.35);
+  transform: translateY(-1px);
+}
+
+.tags li .tag-link:focus-visible {
+  outline: 2px solid rgba(148, 163, 184, 0.9);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.45);
+}
+
+.tags li .tag-link:active {
+  transform: translateY(0);
 }
 
 .ticket-card footer {

--- a/templates/index.html
+++ b/templates/index.html
@@ -226,7 +226,15 @@
         {% if ticket.tags %}
           <ul class="tags">
             {% for tag in ticket.tags %}
-              <li style="--tag-color: {{ tag.color or config.colors.tags.background }}; --tag-text: {{ config.colors.tags.text }}">{{ tag.name }}</li>
+              <li style="--tag-color: {{ tag.color or config.colors.tags.background }}; --tag-text: {{ config.colors.tags.text }}">
+                <a
+                  class="tag-link"
+                  href="{{ tag_filter_url(tag.name, compact_value) }}"
+                  title="Filter by tag {{ tag.name }}"
+                >
+                  {{ tag.name }}
+                </a>
+              </li>
             {% endfor %}
           </ul>
         {% endif %}

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -172,7 +172,15 @@
       <h3>Tags</h3>
       <ul class="tags">
         {% for tag in ticket.tags %}
-          <li style="--tag-color: {{ tag.color or config.colors.tags.background }}; --tag-text: {{ config.colors.tags.text }}">{{ tag.name }}</li>
+          <li style="--tag-color: {{ tag.color or config.colors.tags.background }}; --tag-text: {{ config.colors.tags.text }}">
+            <a
+              class="tag-link"
+              href="{{ tag_filter_url(tag.name, compact_value) }}"
+              title="Filter by tag {{ tag.name }}"
+            >
+              {{ tag.name }}
+            </a>
+          </li>
         {% endfor %}
       </ul>
     </section>


### PR DESCRIPTION
## Summary
- wrap tag pills on the list and detail pages with links that jump to the filtered ticket list
- add a template helper that builds tag filter URLs while preserving existing query parameters
- refresh the tag chip styles so the anchors inherit the pill appearance with hover and focus feedback

## Testing
- pytest
- python -m compileall tickettracker tests

------
https://chatgpt.com/codex/tasks/task_e_68f9fb6230b0832caa5a78d0c4446eed