### PR TITLE
Enhance clipboard fallback previews

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1350,6 +1350,39 @@ body.compact .filter-fields .filter-actions {
   font-size: 0.85rem;
 }
 
+.clipboard-preview {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(
+    155deg,
+    var(--ticket-tint, rgba(56, 189, 248, 0.28)),
+    rgba(15, 23, 42, 0.82)
+  );
+  padding: 1rem;
+  color: var(--text);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.35);
+  overflow: auto;
+}
+
+.clipboard-preview.is-plain {
+  white-space: pre-wrap;
+}
+
+.clipboard-fallback-manual {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.clipboard-fallback-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
 .clipboard-fallback-text {
   width: 100%;
   min-height: 8rem;

--- a/static/js/clipboard.js
+++ b/static/js/clipboard.js
@@ -143,7 +143,27 @@ if (buttons.length) {
     return success;
   };
 
-  const showFallback = (fallbackEl, text) => {
+  const updateFallbackPreview = (fallbackEl, html, text) => {
+    if (!fallbackEl) {
+      return;
+    }
+    const preview = fallbackEl.querySelector('[data-clipboard-preview]');
+    if (!preview) {
+      return;
+    }
+    if (html) {
+      preview.innerHTML = html;
+      preview.classList.remove('is-plain');
+    } else if (text) {
+      preview.textContent = text;
+      preview.classList.add('is-plain');
+    } else {
+      preview.textContent = 'Summary unavailable.';
+      preview.classList.add('is-plain');
+    }
+  };
+
+  const showFallback = (fallbackEl, text, html) => {
     if (!fallbackEl) {
       return false;
     }
@@ -152,6 +172,7 @@ if (buttons.length) {
       return false;
     }
     fallbackEl.hidden = false;
+    updateFallbackPreview(fallbackEl, html, text);
     textarea.value = text;
     textarea.focus();
     textarea.select();
@@ -250,7 +271,7 @@ if (buttons.length) {
         return;
       }
 
-      const fallbackShown = showFallback(fallbackEl, fallbackText);
+      const fallbackShown = showFallback(fallbackEl, fallbackText, htmlContent);
       statusState.fallbackShown = fallbackShown;
       if (fallbackShown) {
         setStatus(

--- a/templates/index.html
+++ b/templates/index.html
@@ -244,11 +244,21 @@
         </footer>
         <div class="clipboard-fallback" data-clipboard-fallback hidden>
           <p>Clipboard access isn't available. Select and copy the summary below.</p>
-          <textarea
-            class="clipboard-fallback-text"
-            data-clipboard-textarea
-            readonly
-          >{{- ticket.clipboard_summary.text | e -}}</textarea>
+          <div class="clipboard-preview" data-clipboard-preview></div>
+          <div class="clipboard-fallback-manual">
+            <label
+              class="clipboard-fallback-label"
+              for="clipboard-fallback-text-{{ ticket.id }}"
+            >
+              Plain text summary
+            </label>
+            <textarea
+              id="clipboard-fallback-text-{{ ticket.id }}"
+              class="clipboard-fallback-text"
+              data-clipboard-textarea
+              readonly
+            >{{- ticket.clipboard_summary.text | e -}}</textarea>
+          </div>
         </div>
         <template data-clipboard-html>{{ ticket.clipboard_summary.html|safe }}</template>
         <template data-clipboard-text>{{- ticket.clipboard_summary.text -}}</template>

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -123,11 +123,21 @@
 
   <div class="clipboard-fallback" data-clipboard-fallback hidden>
     <p>Clipboard access isn't available. Select and copy the summary below.</p>
-    <textarea
-      class="clipboard-fallback-text"
-      data-clipboard-textarea
-      readonly
-    >{{- ticket.clipboard_summary.text | e -}}</textarea>
+    <div class="clipboard-preview" data-clipboard-preview></div>
+    <div class="clipboard-fallback-manual">
+      <label
+        class="clipboard-fallback-label"
+        for="clipboard-fallback-text-{{ ticket.id }}"
+      >
+        Plain text summary
+      </label>
+      <textarea
+        id="clipboard-fallback-text-{{ ticket.id }}"
+        class="clipboard-fallback-text"
+        data-clipboard-textarea
+        readonly
+      >{{- ticket.clipboard_summary.text | e -}}</textarea>
+    </div>
   </div>
   <template data-clipboard-html>{{ ticket.clipboard_summary.html|safe }}</template>
   <template data-clipboard-text>{{- ticket.clipboard_summary.text -}}</template>


### PR DESCRIPTION
## Summary
- add clipboard summary previews and labeled manual copy areas on ticket list and detail pages
- keep fallback previews in sync by injecting the rendered HTML payload when the manual copy flow is shown
- style the new preview container so it visually matches the existing ticket surfaces

## Testing
- pytest tests/test_ticket_updates.py::test_clipboard_summary_generation *(fails: test not found in module)*

------
https://chatgpt.com/codex/tasks/task_e_68f9fe7a439c832c80252a5ad87261ea