### PR TITLE
Add auto-return-to-list behavior flag

### DIFF
--- a/config.json
+++ b/config.json
@@ -77,5 +77,8 @@
     "updates_limit": 1,
     "debug_status": false,
     "inline_styles": true
+  },
+  "behavior": {
+    "auto_return_to_list": false
   }
 }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -120,6 +120,21 @@
       </div>
 
       <div class="field-group checkbox">
+        <label class="checkbox-label" for="auto_return_to_list">
+          <input
+            type="checkbox"
+            id="auto_return_to_list"
+            name="auto_return_to_list"
+            {% if form.auto_return_to_list %}checked{% endif %}
+          />
+          <span>Return to the ticket list after saving</span>
+        </label>
+        <p class="help">
+          When enabled, saving ticket updates or settings navigates back to the ticket list view.
+        </p>
+      </div>
+
+      <div class="field-group checkbox">
         <label class="checkbox-label" for="demo_mode">
           <input
             type="checkbox"

--- a/tests/test_ticket_updates.py
+++ b/tests/test_ticket_updates.py
@@ -2,10 +2,11 @@ import io
 import json
 import sys
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
-from flask import current_app
+from flask import current_app, url_for
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -26,13 +27,13 @@ def _default_config() -> dict:
     return json.loads(json.dumps(DEFAULT_CONFIG))
 
 
-@pytest.fixture()
-def app_with_ticket(tmp_path):
+def _create_app_with_ticket(tmp_path: Path, *, auto_return: bool) -> tuple:
     config_data = _default_config()
     database_path = tmp_path / "app.db"
     uploads_path = tmp_path / "uploads"
     config_data["database"]["uri"] = f"sqlite:///{database_path}"
     config_data["uploads"]["directory"] = str(uploads_path)
+    config_data.setdefault("behavior", {})["auto_return_to_list"] = auto_return
     config_path = _write_config(tmp_path / "config.json", config_data)
 
     app = create_app(config_path)
@@ -49,6 +50,16 @@ def app_with_ticket(tmp_path):
         ticket_id = ticket.id
 
     return app, uploads_path, ticket_id
+
+
+@pytest.fixture()
+def app_with_ticket(tmp_path):
+    return _create_app_with_ticket(tmp_path, auto_return=False)
+
+
+@pytest.fixture()
+def app_with_auto_return_ticket(tmp_path):
+    return _create_app_with_ticket(tmp_path, auto_return=True)
 
 
 def test_auto_attachment_posts_create_update(app_with_ticket):
@@ -73,6 +84,13 @@ def test_auto_attachment_posts_create_update(app_with_ticket):
     )
 
     assert response.status_code == 302
+    redirect_url = urlparse(response.headers["Location"])
+
+    with app.test_request_context():
+        expected_path = url_for("tickets.ticket_detail", ticket_id=ticket_id)
+
+    assert redirect_url.path == expected_path
+    assert parse_qs(redirect_url.query).get("compact") == ["1"]
 
     with app.app_context():
         updates = TicketUpdate.query.filter_by(ticket_id=ticket_id).all()
@@ -96,3 +114,79 @@ def test_auto_attachment_posts_create_update(app_with_ticket):
         for attachment in attachments:
             stored_path = uploads_path / attachment.stored_filename
             assert stored_path.exists(), f"Expected {stored_path} to exist"
+
+
+def test_edit_ticket_redirects_to_detail_by_default(app_with_ticket):
+    app, _, ticket_id = app_with_ticket
+    client = app.test_client()
+
+    response = client.post(
+        f"/tickets/{ticket_id}/edit?compact=0",
+        data={
+            "title": "Updated title",
+            "description": "Updated description",
+            "priority": "Medium",
+            "status": "Open",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    redirect_url = urlparse(response.headers["Location"])
+
+    with app.test_request_context():
+        expected_path = url_for("tickets.ticket_detail", ticket_id=ticket_id)
+
+    assert redirect_url.path == expected_path
+    assert parse_qs(redirect_url.query).get("compact") == ["0"]
+
+
+def test_edit_ticket_redirects_to_list_when_auto_return_enabled(
+    app_with_auto_return_ticket,
+):
+    app, _, ticket_id = app_with_auto_return_ticket
+    client = app.test_client()
+
+    response = client.post(
+        f"/tickets/{ticket_id}/edit?compact=0",
+        data={
+            "title": "Updated title",
+            "description": "Updated description",
+            "priority": "Medium",
+            "status": "Open",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    redirect_url = urlparse(response.headers["Location"])
+
+    with app.test_request_context():
+        expected_path = url_for("tickets.list_tickets")
+
+    assert redirect_url.path == expected_path
+    assert parse_qs(redirect_url.query).get("compact") == ["0"]
+
+
+def test_add_update_redirects_to_list_when_auto_return_enabled(
+    app_with_auto_return_ticket,
+):
+    app, _, ticket_id = app_with_auto_return_ticket
+    client = app.test_client()
+
+    response = client.post(
+        f"/tickets/{ticket_id}/updates?compact=0",
+        data={
+            "message": "Follow-up note",
+            "status": "Open",
+        },
+    )
+
+    assert response.status_code == 302
+    redirect_url = urlparse(response.headers["Location"])
+
+    with app.test_request_context():
+        expected_path = url_for("tickets.list_tickets")
+
+    assert redirect_url.path == expected_path
+    assert parse_qs(redirect_url.query).get("compact") == ["0"]

--- a/tickettracker/views/tickets.py
+++ b/tickettracker/views/tickets.py
@@ -675,11 +675,16 @@ def edit_ticket(ticket_id: int):
         _store_attachments(request.files.getlist("attachments"), ticket)
         db.session.commit()
         flash("Ticket updated", "success")
+        compact_value = _compact_query_value(compact_mode)
+        if config.behavior.auto_return_to_list:
+            return redirect(
+                url_for("tickets.list_tickets", compact=compact_value)
+            )
         return redirect(
             url_for(
                 "tickets.ticket_detail",
                 ticket_id=ticket.id,
-                compact=_compact_query_value(compact_mode),
+                compact=compact_value,
             )
         )
 
@@ -749,11 +754,14 @@ def add_update(ticket_id: int):
 
     db.session.commit()
     flash("Update added", "success")
+    compact_value = _compact_query_value(compact_mode)
+    if config.behavior.auto_return_to_list:
+        return redirect(url_for("tickets.list_tickets", compact=compact_value))
     return redirect(
         url_for(
             "tickets.ticket_detail",
             ticket_id=ticket.id,
-            compact=_compact_query_value(compact_mode),
+            compact=compact_value,
         )
     )
 


### PR DESCRIPTION
## Summary
- add a behavior configuration section with an auto_return_to_list flag and load it into AppConfig
- expose the new option on the settings page and update redirects in tickets and settings views
- extend ticket and settings tests to cover redirect destinations based on the flag

## Testing
- pytest tests/test_ticket_updates.py tests/test_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68fa00f80d3c832cb15b3aa487cf45fb