### PR TITLE
Add interactive compact ticket tooltips

### DIFF
--- a/static/css/ticket-tooltips.css
+++ b/static/css/ticket-tooltips.css
@@ -1,0 +1,158 @@
+.ticket-card .ticket-tooltip[hidden] {
+  display: none !important;
+}
+
+.ticket-card .ticket-tooltip {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: min(22rem, calc(100% - 2rem));
+  background: color-mix(in srgb, rgba(15, 23, 42, 0.94) 88%, var(--ticket-accent, rgba(56, 189, 248, 0.3)) 12%);
+  border: 1px solid color-mix(in srgb, var(--ticket-accent, rgba(56, 189, 248, 0.45)) 55%, transparent 45%);
+  border-radius: 1.25rem;
+  box-shadow: 0 20px 48px rgba(2, 6, 23, 0.55);
+  padding: 0;
+  opacity: 0;
+  transform: translate3d(0, -0.75rem, 0);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  pointer-events: none;
+  z-index: 8;
+  color: var(--text, #e2e8f0);
+}
+
+.ticket-card .ticket-tooltip.is-visible {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+  pointer-events: auto;
+}
+
+.ticket-tooltip__surface {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  outline: none;
+}
+
+.ticket-tooltip__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.ticket-tooltip__title {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.ticket-tooltip__close {
+  appearance: none;
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--ticket-accent, rgba(56, 189, 248, 0.35)) 25%, transparent 75%);
+  color: var(--text-muted, #94a3b8);
+  border-radius: 999px;
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.ticket-tooltip__close:hover,
+.ticket-tooltip__close:focus-visible {
+  color: #f8fafc;
+  border-color: color-mix(in srgb, var(--ticket-accent, #38bdf8) 60%, transparent 40%);
+}
+
+.ticket-tooltip__close:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ticket-accent, #38bdf8) 65%, transparent 35%);
+  outline-offset: 2px;
+}
+
+.ticket-tooltip__meta {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.ticket-tooltip__item dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted, #94a3b8);
+  margin: 0 0 0.25rem;
+}
+
+.ticket-tooltip__item dd {
+  margin: 0;
+  font-weight: 500;
+  color: inherit;
+}
+
+.ticket-tooltip__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.ticket-tooltip__section h4 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted, #94a3b8);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+.ticket-tooltip__links,
+.ticket-tooltip__attachments {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.ticket-tooltip__attachments li,
+.ticket-tooltip__links li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.ticket-tooltip__attachments a,
+.ticket-tooltip__links a {
+  color: var(--ticket-title-color, #f8fafc);
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.ticket-tooltip__attachments a:hover,
+.ticket-tooltip__attachments a:focus-visible,
+.ticket-tooltip__links a:hover,
+.ticket-tooltip__links a:focus-visible {
+  text-decoration: underline;
+}
+
+.ticket-tooltip__attachment-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted, #94a3b8);
+}
+
+@media (max-width: 720px) {
+  .ticket-card .ticket-tooltip {
+    position: fixed;
+    inset: auto 1.5rem 2rem 1.5rem;
+    width: auto;
+    max-width: min(28rem, calc(100vw - 3rem));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ticket-card .ticket-tooltip {
+    transition: none;
+  }
+}

--- a/static/js/ticket-tooltips.js
+++ b/static/js/ticket-tooltips.js
@@ -1,0 +1,210 @@
+class TicketTooltipController {
+  constructor(trigger, tooltip) {
+    this.trigger = trigger;
+    this.tooltip = tooltip;
+    this.surface = tooltip.querySelector('[data-tooltip-surface]') || tooltip;
+    this.closeButton = tooltip.querySelector('[data-tooltip-close]');
+    this.hideTimeout = null;
+    this.active = false;
+    this.hovering = false;
+    this.focusWithin = false;
+
+    this.onTriggerPointerEnter = this.onTriggerPointerEnter.bind(this);
+    this.onTriggerPointerLeave = this.onTriggerPointerLeave.bind(this);
+    this.onTooltipPointerEnter = this.onTooltipPointerEnter.bind(this);
+    this.onTooltipPointerLeave = this.onTooltipPointerLeave.bind(this);
+    this.onFocusIn = this.onFocusIn.bind(this);
+    this.onFocusOut = this.onFocusOut.bind(this);
+    this.onKeyDown = this.onKeyDown.bind(this);
+
+    trigger.addEventListener('pointerenter', this.onTriggerPointerEnter);
+    trigger.addEventListener('pointerleave', this.onTriggerPointerLeave);
+    trigger.addEventListener('focusin', this.onFocusIn);
+    trigger.addEventListener('focusout', this.onFocusOut);
+    trigger.addEventListener('keydown', this.onKeyDown);
+
+    tooltip.addEventListener('pointerenter', this.onTooltipPointerEnter);
+    tooltip.addEventListener('pointerleave', this.onTooltipPointerLeave);
+    tooltip.addEventListener('focusin', this.onFocusIn);
+    tooltip.addEventListener('focusout', this.onFocusOut);
+    tooltip.addEventListener('keydown', this.onKeyDown);
+
+    if (this.closeButton) {
+      this.closeButton.addEventListener('click', () => this.close({ returnFocus: true }));
+    }
+
+    trigger.setAttribute('aria-expanded', 'false');
+    trigger.setAttribute('aria-haspopup', 'dialog');
+  }
+
+  open({ focusSurface = false } = {}) {
+    if (this.active) {
+      return;
+    }
+    this.active = true;
+    if (this.hideTimeout) {
+      window.clearTimeout(this.hideTimeout);
+      this.hideTimeout = null;
+    }
+    this.tooltip.hidden = false;
+    requestAnimationFrame(() => {
+      this.tooltip.classList.add('is-visible');
+    });
+    this.tooltip.setAttribute('aria-hidden', 'false');
+    this.trigger.setAttribute('aria-expanded', 'true');
+    if (focusSurface && this.surface) {
+      this.surface.focus({ preventScroll: true });
+    }
+  }
+
+  close({ returnFocus = false } = {}) {
+    if (!this.active) {
+      return;
+    }
+    this.active = false;
+    this.tooltip.classList.remove('is-visible');
+    this.tooltip.setAttribute('aria-hidden', 'true');
+    this.trigger.setAttribute('aria-expanded', 'false');
+    this.hovering = false;
+    this.focusWithin = false;
+    if (this.hideTimeout) {
+      window.clearTimeout(this.hideTimeout);
+    }
+    this.hideTimeout = window.setTimeout(() => {
+      this.tooltip.hidden = true;
+      this.hideTimeout = null;
+    }, 180);
+    if (returnFocus) {
+      this.trigger.focus({ preventScroll: true });
+    }
+  }
+
+  containsWithin(node) {
+    if (!node) {
+      return false;
+    }
+    return this.trigger.contains(node) || this.tooltip.contains(node);
+  }
+
+  onTriggerPointerEnter() {
+    this.hovering = true;
+    this.open();
+  }
+
+  onTriggerPointerLeave(event) {
+    if (this.containsWithin(event.relatedTarget)) {
+      return;
+    }
+    this.hovering = false;
+    if (!this.focusWithin) {
+      this.close();
+    }
+  }
+
+  onTooltipPointerEnter() {
+    this.hovering = true;
+  }
+
+  onTooltipPointerLeave(event) {
+    if (this.containsWithin(event.relatedTarget)) {
+      return;
+    }
+    this.hovering = false;
+    if (!this.focusWithin) {
+      this.close();
+    }
+  }
+
+  onFocusIn(event) {
+    if (!this.containsWithin(event.target)) {
+      return;
+    }
+    this.focusWithin = true;
+    this.open({ focusSurface: this.tooltip === event.target });
+  }
+
+  onFocusOut(event) {
+    if (this.containsWithin(event.relatedTarget)) {
+      return;
+    }
+    this.focusWithin = false;
+    if (!this.hovering) {
+      this.close();
+    }
+  }
+
+  onKeyDown(event) {
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      if (!this.active) {
+        return;
+      }
+      event.preventDefault();
+      this.close({ returnFocus: true });
+      return;
+    }
+
+    if (event.key !== 'Tab' || !this.active) {
+      return;
+    }
+
+    const focusables = this.getFocusableElements();
+    if (focusables.length === 0) {
+      event.preventDefault();
+      return;
+    }
+
+    const current = document.activeElement;
+    if (!this.tooltip.contains(current)) {
+      return;
+    }
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    if (event.shiftKey) {
+      if (current === first) {
+        event.preventDefault();
+        last.focus({ preventScroll: true });
+      }
+    } else if (current === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
+  }
+
+  getFocusableElements() {
+    const selectors = [
+      'a[href]:not([tabindex="-1"])',
+      'button:not([disabled]):not([tabindex="-1"])',
+      'textarea:not([disabled]):not([tabindex="-1"])',
+      'input:not([disabled]):not([tabindex="-1"])',
+      'select:not([disabled]):not([tabindex="-1"])',
+      '[tabindex]:not([tabindex="-1"])',
+    ];
+    return Array.from(this.tooltip.querySelectorAll(selectors.join(',')));
+  }
+}
+
+function initializeTicketTooltips() {
+  const triggers = document.querySelectorAll('[data-ticket-tooltip-trigger]');
+  triggers.forEach((trigger) => {
+    const tooltipId = trigger.getAttribute('data-tooltip-id');
+    if (!tooltipId) {
+      return;
+    }
+    const tooltip = document.getElementById(tooltipId);
+    if (!tooltip) {
+      return;
+    }
+    if (!tooltip.hasAttribute('data-ticket-tooltip')) {
+      return;
+    }
+    new TicketTooltipController(trigger, tooltip);
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeTicketTooltips);
+} else {
+  initializeTicketTooltips();
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}TicketTracker{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
+    {% block extra_styles %}{% endblock %}
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,9 @@
 {% extends "base.html" %}
+
+{% block extra_styles %}
+  {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/ticket-tooltips.css') }}" />
+{% endblock %}
 {% block title %}Tickets · TicketTracker{% endblock %}
 {% block content %}
 {% set is_compact = compact_mode|default(true) %}
@@ -117,10 +122,13 @@
         data-overdue="{{ 'true' if ticket.is_overdue else 'false' }}"
         style="--ticket-accent: {{ ticket.display_color }}; --ticket-tint: {{ ticket.tint_color }};"
         {% if is_compact and ticket.compact_tooltip %}
-          title="{{ ticket.compact_tooltip }}"
-          aria-label="{{ ticket.compact_tooltip }}"
+          data-ticket-tooltip-trigger
+          data-tooltip-id="ticket-tooltip-{{ ticket.id }}"
+          aria-describedby="ticket-tooltip-{{ ticket.id }}"
+          tabindex="-1"
         {% endif %}
       >
+        {% set tooltip = ticket.compact_tooltip %}
         <header>
           <div class="title-group">
             <h2 class="ticket-title">
@@ -242,6 +250,79 @@
           <span>{{ ticket.updates|length }} updates</span>
           <span>{{ ticket.attachments|length }} attachments</span>
         </footer>
+        {% if is_compact and tooltip %}
+          <div
+            class="ticket-tooltip"
+            id="ticket-tooltip-{{ ticket.id }}"
+            data-ticket-tooltip
+            role="dialog"
+            aria-modal="false"
+            aria-hidden="true"
+            aria-labelledby="ticket-tooltip-title-{{ ticket.id }}"
+            hidden
+          >
+            <div class="ticket-tooltip__surface" data-tooltip-surface tabindex="-1">
+              <header class="ticket-tooltip__header">
+                <h3 class="ticket-tooltip__title" id="ticket-tooltip-title-{{ ticket.id }}">Quick ticket info</h3>
+                <button type="button" class="ticket-tooltip__close" data-tooltip-close aria-label="Close quick info">
+                  <span aria-hidden="true">×</span>
+                </button>
+              </header>
+              {% if tooltip.requester or tooltip.watchers %}
+                <dl class="ticket-tooltip__meta">
+                  {% if tooltip.requester %}
+                    <div class="ticket-tooltip__item">
+                      <dt>Requester</dt>
+                      <dd>{{ tooltip.requester }}</dd>
+                    </div>
+                  {% endif %}
+                  {% if tooltip.watchers %}
+                    <div class="ticket-tooltip__item">
+                      <dt>Watchers</dt>
+                      <dd>{{ tooltip.watchers|join(', ') }}</dd>
+                    </div>
+                  {% endif %}
+                </dl>
+              {% endif %}
+              {% if tooltip.links %}
+                <div class="ticket-tooltip__section">
+                  <h4>Links</h4>
+                  <ul class="ticket-tooltip__links">
+                    {% for link in tooltip.links %}
+                      <li>
+                        {% if link.href %}
+                          <a
+                            href="{{ link.href }}"
+                            {% if link.is_external %}target="_blank" rel="noreferrer noopener"{% endif %}
+                          >
+                            {{ link.label }}
+                          </a>
+                        {% else %}
+                          <span>{{ link.label }}</span>
+                        {% endif %}
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              {% endif %}
+              {% if tooltip.attachments %}
+                <div class="ticket-tooltip__section">
+                  <h4>Attachments</h4>
+                  <ul class="ticket-tooltip__attachments">
+                    {% for attachment in tooltip.attachments %}
+                      <li>
+                        <a href="{{ attachment.download_url }}">{{ attachment.display_name }}</a>
+                        {% if attachment.meta %}
+                          <span class="ticket-tooltip__attachment-meta">{{ attachment.meta }}</span>
+                        {% endif %}
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              {% endif %}
+            </div>
+          </div>
+        {% endif %}
         <div class="clipboard-fallback" data-clipboard-fallback hidden>
           <p>Clipboard access isn't available. Select and copy the summary below.</p>
           <div class="clipboard-preview" data-clipboard-preview></div>
@@ -337,5 +418,6 @@
 
 {% block scripts %}
   {{ super() }}
+  <script type="module" src="{{ url_for('static', filename='js/ticket-tooltips.js') }}"></script>
   <script type="module" src="{{ url_for('static', filename='js/clipboard.js') }}"></script>
 {% endblock %}

--- a/tests/test_ticket_tooltips.py
+++ b/tests/test_ticket_tooltips.py
@@ -1,0 +1,87 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+  sys.path.insert(0, str(ROOT))
+
+from tickettracker.app import create_app
+from tickettracker.config import DEFAULT_CONFIG
+from tickettracker.extensions import db
+from tickettracker.models import Attachment, Ticket
+
+
+def _write_config(target: Path, data: dict) -> Path:
+  target.write_text(json.dumps(data, indent=2))
+  return target
+
+
+def _default_config() -> dict:
+  return json.loads(json.dumps(DEFAULT_CONFIG))
+
+
+@pytest.fixture()
+def tooltip_app(tmp_path):
+  config = _default_config()
+  database_path = tmp_path / "app.db"
+  uploads_path = tmp_path / "uploads"
+  config["database"]["uri"] = f"sqlite:///{database_path}"
+  config["uploads"]["directory"] = str(uploads_path)
+  config_path = _write_config(tmp_path / "config.json", config)
+
+  app = create_app(config_path)
+
+  with app.app_context():
+    ticket = Ticket(
+      title="Tooltip Ticket",
+      description="Ensure compact tooltips render rich metadata.",
+      priority="High",
+      status="Open",
+    )
+    db.session.add(ticket)
+    db.session.commit()
+    ticket_id = ticket.id
+
+  return app, ticket_id
+
+
+def test_compact_tooltip_renders_interactive_card(tooltip_app):
+  app, ticket_id = tooltip_app
+
+  with app.app_context():
+    ticket = Ticket.query.get(ticket_id)
+    ticket.requester = "Ava Analyst"
+    ticket.watchers = ["Bea Builder", "Cal Collaborator"]
+    ticket.links = "https://example.com/docs\nInternal Checklist"
+    attachment = Attachment(
+      ticket=ticket,
+      original_filename="report.pdf",
+      stored_filename="report.pdf",
+      mimetype="application/pdf",
+      size=2048,
+    )
+    db.session.add(attachment)
+    db.session.commit()
+    attachment_id = attachment.id
+
+  client = app.test_client()
+  response = client.get("/")
+
+  assert response.status_code == 200
+  html = response.get_data(as_text=True)
+
+  assert f'data-tooltip-id="ticket-tooltip-{ticket_id}"' in html
+  assert f'id="ticket-tooltip-{ticket_id}"' in html
+  assert 'class="ticket-tooltip"' in html
+  assert "Quick ticket info" in html
+  assert "Ava Analyst" in html
+  assert "Bea Builder, Cal Collaborator" in html
+  assert "https://example.com/docs" in html
+  assert "Internal Checklist" in html
+  assert f"/attachments/{attachment_id}" in html
+  assert "application/pdf" in html
+  assert "2 KB" in html
+  assert 'data-ticket-tooltip-trigger' in html


### PR DESCRIPTION
## Summary
- build structured tooltip context for compact ticket cards including links, watchers, and attachment metadata
- render accessible tooltip cards in the compact grid and add supporting CSS/JS interactions
- cover the tooltip rendering with an integration test

## Testing
- pytest tests/test_ticket_tooltips.py
- pytest tests/test_ticket_updates.py

------
https://chatgpt.com/codex/tasks/task_e_68fa0d06d8a8832cba85d78b0adfbd47