### PR TITLE
Use icons for attachment delete controls

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -460,6 +460,22 @@ body.compact .ticket-detail .attachments {
   box-shadow: 0 16px 36px rgba(2, 6, 23, 0.32);
 }
 
+body.compact .attachment-item {
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+body.compact .attachment-delete-button {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.5rem;
+}
+
+body.compact .attachment-delete-button .icon svg {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
 body.compact .ticket-detail .tag-list h3,
 body.compact .ticket-detail .attachments h3 {
   margin-bottom: 0.75rem;
@@ -1548,6 +1564,54 @@ body.compact .filter-fields .filter-actions {
   margin: 0;
   display: grid;
   gap: 0.5rem;
+}
+
+.attachment-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.attachment-main {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.attachment-delete-form {
+  margin: 0;
+}
+
+.attachment-delete-button {
+  background: none;
+  border: 0;
+  color: var(--danger);
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border-radius: 0.6rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.attachment-delete-button .icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.attachment-delete-button .icon svg {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.attachment-delete-button:hover,
+.attachment-delete-button:focus-visible {
+  background: rgba(248, 113, 113, 0.12);
+  color: #fecaca;
 }
 
 .attachment-meta {

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -201,11 +201,34 @@
       <h3>Attachments</h3>
       <ul>
         {% for attachment in ticket.attachments %}
-          <li>
-            <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id, compact=compact_value) }}">
-              {{ attachment.display_name }}
-            </a>
-            <span class="attachment-meta">Uploaded {{ attachment.uploaded_at.strftime('%b %d, %Y %H:%M') }}</span>
+          <li class="attachment-item">
+            <div class="attachment-main">
+              <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id, compact=compact_value) }}">
+                {{ attachment.display_name }}
+              </a>
+              <span class="attachment-meta">Uploaded {{ attachment.uploaded_at.strftime('%b %d, %Y %H:%M') }}</span>
+            </div>
+            <form
+              method="post"
+              action="{{ url_for('tickets.delete_attachment', attachment_id=attachment.id, compact=compact_value) }}"
+              class="attachment-delete-form"
+            >
+              <button type="submit" class="attachment-delete-button icon-button">
+                <span class="icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                    <path
+                      d="M6 7h12M9 7V5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2m-8 0v12a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V7"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.7"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    ></path>
+                  </svg>
+                </span>
+                <span class="sr-only">Delete attachment {{ attachment.display_name }}</span>
+              </button>
+            </form>
           </li>
         {% endfor %}
       </ul>
@@ -233,10 +256,33 @@
             {% if update.attachments %}
               <ul class="update-attachments">
                 {% for attachment in update.attachments %}
-                  <li>
-                    <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id, compact=compact_value) }}">
-                      {{ attachment.display_name }}
-                    </a>
+                  <li class="attachment-item">
+                    <div class="attachment-main">
+                      <a href="{{ url_for('tickets.download_attachment', attachment_id=attachment.id, compact=compact_value) }}">
+                        {{ attachment.display_name }}
+                      </a>
+                    </div>
+                    <form
+                      method="post"
+                      action="{{ url_for('tickets.delete_attachment', attachment_id=attachment.id, compact=compact_value) }}"
+                      class="attachment-delete-form"
+                    >
+                      <button type="submit" class="attachment-delete-button icon-button">
+                        <span class="icon" aria-hidden="true">
+                          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                            <path
+                              d="M6 7h12M9 7V5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2m-8 0v12a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V7"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-width="1.7"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                            ></path>
+                          </svg>
+                        </span>
+                        <span class="sr-only">Delete attachment {{ attachment.display_name }}</span>
+                      </button>
+                    </form>
                   </li>
                 {% endfor %}
               </ul>


### PR DESCRIPTION
## Summary
- replace the attachment delete button text with an icon + sr-only label on ticket and update attachments
- adjust the delete button styling, including compact sizing, for the icon presentation

## Testing
- pytest tests/test_ticket_updates.py::test_delete_attachment_cleans_file

------
https://chatgpt.com/codex/tasks/task_e_68fa10671e7c832c977341b7e614e4a3