### PR TITLE
Add configurable color palette controls

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -983,6 +983,92 @@ body.compact .filter-fields .filter-actions {
   display: none;
 }
 
+.color-settings .color-palette {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.color-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.color-section h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.color-section-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.color-entry {
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.color-entry-label {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.color-chip {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.6) inset;
+}
+
+.color-entry-inputs {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.color-entry-inputs input[type="color"] {
+  border: none;
+  padding: 0;
+  width: 3rem;
+  height: 2.25rem;
+  background: transparent;
+  cursor: pointer;
+}
+
+.color-entry-inputs input[type="color"]::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.color-entry-inputs input[type="color"]::-webkit-color-swatch {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.5rem;
+}
+
+.color-entry-inputs input[type="color"]::-moz-color-swatch {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.5rem;
+}
+
+.color-hex-input {
+  flex: 1 1 8ch;
+  min-width: 0;
+  text-transform: uppercase;
+}
+
 .tag-mode {
   display: flex;
   gap: 1rem;

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -146,6 +146,52 @@
         </div>
       </fieldset>
 
+      <fieldset class="field-group color-settings">
+        <legend>Colors</legend>
+        <p class="help">
+          Customize the ticket palette. Leave a hex value blank to restore the default
+          color.
+        </p>
+        <div class="color-palette">
+          {% for section in color_sections %}
+            <div class="color-section">
+              <h3>{{ section.label }}</h3>
+              <div class="color-section-grid">
+                {% for entry in section.entries %}
+                  {% set key_slug = entry.key|lower|replace(' ', '-')|replace('/', '-')|replace('[', '-')|replace(']', '-') %}
+                  {% set input_id = "color_%s_%s" | format(section.name, key_slug) %}
+                  <div class="color-entry">
+                    <div class="color-entry-label">
+                      <span class="color-chip" style="background-color: {{ entry.value }}" aria-hidden="true"></span>
+                      <span>{{ entry.label }}</span>
+                    </div>
+                    <div class="color-entry-inputs">
+                      <input
+                        type="color"
+                        id="{{ input_id }}"
+                        name="{{ entry.field_name }}"
+                        value="{{ entry.value }}"
+                        aria-label="{{ entry.label }} color"
+                      />
+                      <input
+                        type="text"
+                        class="color-hex-input"
+                        name="{{ entry.text_field_name }}"
+                        value="{{ entry.text }}"
+                        placeholder="{{ entry.default }}"
+                        pattern="#?[0-9a-fA-F]{3}([0-9a-fA-F]{3})?"
+                        title="Enter a hex color like #AABBCC or #ABC"
+                        aria-label="{{ entry.label }} hex value"
+                      />
+                    </div>
+                  </div>
+                {% endfor %}
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+      </fieldset>
+
       <fieldset class="field-group clipboard-sections">
         <legend>Clipboard sections</legend>
         <table class="clipboard-sections-table">


### PR DESCRIPTION
## Summary
- add color palette helpers for the settings workflow and persist normalized hex values
- expose a Colors fieldset in the settings template with color pickers and hex inputs
- style the new color controls and add regression coverage for editing the palette

## Testing
- pytest tests/test_settings.py::test_update_color_palette

------
https://chatgpt.com/codex/tasks/task_e_68fa105b8458832c82fc26a90bc4bf19