### PR TITLE
Arrange settings textareas in responsive grid

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -925,6 +925,28 @@ body.compact .filter-fields .filter-actions {
   }
 }
 
+.field-row {
+  display: grid;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.field-row--thirds {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 768px) {
+  .field-row--thirds {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1100px) {
+  .field-row--thirds {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 .field-group {
   display: flex;
   flex-direction: column;
@@ -941,6 +963,7 @@ body.compact .filter-fields .filter-actions {
 .field-group input,
 .field-group textarea,
 .field-group select {
+  width: 100%;
   background: rgba(15, 23, 42, 0.6);
   border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 0.75rem;

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -28,37 +28,39 @@
         />
       </div>
 
-      <div class="field-group">
-        <label for="priorities">Priorities</label>
-        <textarea
-          id="priorities"
-          name="priorities"
-          rows="4"
-          required
-        >{{- form.priorities|default('') -}}</textarea>
-        <p class="help">Enter one priority per line, ordered from lowest to highest.</p>
-      </div>
+      <div class="field-row field-row--thirds">
+        <div class="field-group">
+          <label for="priorities">Priorities</label>
+          <textarea
+            id="priorities"
+            name="priorities"
+            rows="4"
+            required
+          >{{- form.priorities|default('') -}}</textarea>
+          <p class="help">Enter one priority per line, ordered from lowest to highest.</p>
+        </div>
 
-      <div class="field-group">
-        <label for="hold_reasons">Hold reasons</label>
-        <textarea
-          id="hold_reasons"
-          name="hold_reasons"
-          rows="4"
-          required
-        >{{- form.hold_reasons|default('') -}}</textarea>
-        <p class="help">Use one reason per line to populate the on-hold dropdown.</p>
-      </div>
+        <div class="field-group">
+          <label for="hold_reasons">Hold reasons</label>
+          <textarea
+            id="hold_reasons"
+            name="hold_reasons"
+            rows="4"
+            required
+          >{{- form.hold_reasons|default('') -}}</textarea>
+          <p class="help">Use one reason per line to populate the on-hold dropdown.</p>
+        </div>
 
-      <div class="field-group">
-        <label for="workflow">Workflow statuses</label>
-        <textarea
-          id="workflow"
-          name="workflow"
-          rows="4"
-          required
-        >{{- form.workflow|default('') -}}</textarea>
-        <p class="help">List statuses in the order they should appear in dropdowns.</p>
+        <div class="field-group">
+          <label for="workflow">Workflow statuses</label>
+          <textarea
+            id="workflow"
+            name="workflow"
+            rows="4"
+            required
+          >{{- form.workflow|default('') -}}</textarea>
+          <p class="help">List statuses in the order they should appear in dropdowns.</p>
+        </div>
       </div>
 
       <fieldset class="field-group sla-settings">


### PR DESCRIPTION
## Summary
- wrap the priorities, hold reasons, and workflow textareas in a shared grid row so they render as columns together
- add responsive layout rules for the new grid row and ensure text inputs expand to the full column width for aligned help text

## Testing
- `pytest` *(fails: tests/test_settings.py::test_settings_update_persists_between_app_starts expects auto_return_to_list to persist as True)*

------
https://chatgpt.com/codex/tasks/task_e_68fa1dc6f4c4832c9776350fae5542d1