### PR TITLE
Rework settings form header layout

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -931,11 +931,44 @@ body.compact .filter-fields .filter-actions {
   align-items: start;
 }
 
+.settings-header-row {
+  display: grid;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.settings-header-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-header-control.field-group {
+  width: 100%;
+}
+
 .field-row--thirds {
   grid-template-columns: minmax(0, 1fr);
 }
 
 @media (min-width: 768px) {
+  .settings-header-row {
+    grid-template-columns: minmax(0, 3fr) minmax(0, 1fr);
+    align-items: end;
+  }
+
+  .settings-header-control.field-group {
+    justify-self: end;
+    align-items: flex-end;
+    text-align: right;
+    max-width: 22rem;
+  }
+
+  .settings-header-control.field-group label {
+    width: 100%;
+    text-align: right;
+  }
+
   .field-row--thirds {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -4,28 +4,32 @@
 {% block title %}Settings · TicketTracker{% endblock %}
 {% block content %}
   <section class="panel settings-panel">
-    <h2>Application settings</h2>
-    <p class="help">
-      {% if config.source_path %}
-        Changes are saved to <code>{{ config.source_path }}</code>.
-      {% else %}
-        Changes are saved to the default configuration file.
-      {% endif %}
-    </p>
     <form
       method="post"
       action="{{ url_for('settings.view_settings', compact=compact_value) }}"
       class="settings-form"
     >
-      <div class="field-group">
-        <label for="default_submitted_by">Default submitted by</label>
-        <input
-          type="text"
-          id="default_submitted_by"
-          name="default_submitted_by"
-          value="{{ form.default_submitted_by|default('') }}"
-          required
-        />
+      <div class="settings-header-row">
+        <div class="settings-header-intro">
+          <h2>Application settings</h2>
+          <p class="help">
+            {% if config.source_path %}
+              Changes are saved to <code>{{ config.source_path }}</code>.
+            {% else %}
+              Changes are saved to the default configuration file.
+            {% endif %}
+          </p>
+        </div>
+        <div class="settings-header-control field-group">
+          <label for="default_submitted_by">Default submitted by</label>
+          <input
+            type="text"
+            id="default_submitted_by"
+            name="default_submitted_by"
+            value="{{ form.default_submitted_by|default('') }}"
+            required
+          />
+        </div>
       </div>
 
       <div class="field-row field-row--thirds">


### PR DESCRIPTION
## Summary
- restructure the settings form header so the heading/help text and default submitter control share a responsive two-column layout
- add styles for the new header grid, keeping typography consistent and collapsing to a single column on small screens

## Testing
- pytest *(fails: tests/test_settings.py::test_settings_update_persists_between_app_starts)*

------
https://chatgpt.com/codex/tasks/task_e_68fa1fd3d8d8832c8fdf32799c4dfb89