### PR TITLE
Refine clipboard summary badges and spacing

### DIFF
--- a/templates/partials/ticket_clipboard_summary.html
+++ b/templates/partials/ticket_clipboard_summary.html
@@ -18,7 +18,7 @@
 {% set timeline_surface = 'rgba(255, 255, 255, 0.92)' %}
 {% set timeline_border = 'rgba(148, 163, 184, 0.28)' %}
 {% set article_background = "linear-gradient(160deg, rgba(248, 250, 252, 0.98) 0%, rgba(241, 245, 249, 0.96) 55%, rgba(226, 232, 240, 0.94) 100%), linear-gradient(120deg, " ~ tint_color ~ " 0%, rgba(248, 250, 252, 0) 70%)" %}
-{% set tag_text_color = config.colors.tags.get('text', '#0f172a') %}
+{% set tag_text_color = config.colors.tags.get('text', '#e2e8f0') %}
 {% set article_properties = [
   '--ticket-accent: ' ~ accent_color,
   '--ticket-tint: ' ~ tint_color,
@@ -36,30 +36,33 @@
   '--clipboard-timeline-surface: ' ~ timeline_surface,
   '--clipboard-timeline-border: ' ~ timeline_border,
 ] %}
-{% set article_style_parts = article_properties + ([
-  "font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif",
+{% set article_required_styles = [
   "background: " ~ article_background,
+  "background-clip: padding-box",
   "color: " ~ text_color,
+] %}
+{% set article_optional_styles = [
+  "font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif",
   "border-radius: 28px",
   "border: 1px solid " ~ section_border,
-  "padding: 32px",
+  "padding: 24px",
   "box-sizing: border-box",
   "width: 100%",
   "line-height: 1.6",
-  "background-clip: padding-box",
   "box-shadow: " ~ article_shadow,
-] if use_inline_styles else []) %}
+] %}
+{% set article_style_parts = article_properties + article_required_styles + (article_optional_styles if use_inline_styles else []) %}
 {% set article_style = article_style_parts | join('; ') %}
-{% set header_style = "display: flex; justify-content: space-between; gap: 24px; align-items: flex-start; margin-bottom: 28px; padding: 24px; border-radius: 24px; background: " ~ section_strong_background ~ "; border: 1px solid " ~ section_border ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
-{% set title_group_style = "display: flex; flex-direction: column; gap: 12px;" if use_inline_styles else "" %}
+{% set header_style = "display: flex; justify-content: space-between; gap: 20px; align-items: flex-start; margin-bottom: 24px; padding: 20px; border-radius: 24px; background: " ~ section_strong_background ~ "; border: 1px solid " ~ section_border ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
+{% set title_group_style = "display: flex; flex-direction: column; gap: 10px;" if use_inline_styles else "" %}
 {% set title_style = "margin: 0; font-size: 28px; line-height: 1.2; color: " ~ title_color ~ ";" if use_inline_styles else "" %}
-{% set timestamps_style = "display: flex; flex-direction: column; gap: 6px; font-size: 13px; color: " ~ muted_color ~ "; text-align: right;" if use_inline_styles else "" %}
-{% set section_style = "margin-top: 28px; padding: 24px; border-radius: 24px; background: " ~ section_background ~ "; border: 1px solid " ~ section_border ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
-{% set section_heading_style = "margin: 0 0 12px 0; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; color: " ~ muted_color ~ ";" if use_inline_styles else "" %}
+{% set timestamps_style = "display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: " ~ muted_color ~ "; text-align: right;" if use_inline_styles else "" %}
+{% set section_style = "margin-top: 24px; padding: 20px; border-radius: 24px; background: " ~ section_background ~ "; border: 1px solid " ~ section_border ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
+{% set section_heading_style = "margin: 0 0 10px 0; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; color: " ~ muted_color ~ ";" if use_inline_styles else "" %}
 {% set paragraph_style = "margin: 0; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
 {% set table_style = "width: 100%; border-collapse: collapse;" if use_inline_styles else "" %}
-{% set th_style = "padding: 6px 0; width: 32%; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: " ~ muted_color ~ "; vertical-align: top;" if use_inline_styles else "" %}
-{% set td_style = "padding: 6px 0; color: " ~ text_color ~ "; vertical-align: top;" if use_inline_styles else "" %}
+{% set th_style = "padding: 5px 0; width: 32%; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: " ~ muted_color ~ "; vertical-align: top;" if use_inline_styles else "" %}
+{% set td_style = "padding: 5px 0; color: " ~ text_color ~ "; vertical-align: top;" if use_inline_styles else "" %}
 {% set badge_base_style = "display: inline-flex; align-items: center; justify-content: center; padding: 4px 12px; border-radius: 999px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; white-space: nowrap; box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12); border: 1px solid rgba(148, 163, 184, 0.35);" if use_inline_styles else "" %}
 {% set status_badge_style = badge_base_style + " background: " + status_color + "; color: #f8fafc;" if badge_base_style else "" %}
 {% set priority_badge_style = badge_base_style + " background: " + priority_color + "; color: #0f172a; box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.35), 0 8px 16px rgba(2, 6, 23, 0.35);" if badge_base_style else "" %}
@@ -67,14 +70,13 @@
 {% set sla_badge_style = badge_base_style + " background: rgba(56, 189, 248, 0.35); color: #f8fafc;" if badge_base_style else "" %}
 {% set status_note_style = "margin-left: 8px; font-size: 12px; color: " ~ muted_color ~ "; letter-spacing: 0.03em;" if use_inline_styles else "" %}
 {% set inline_hint_style = "margin-left: 8px; font-size: 12px; color: " ~ muted_color ~ "; letter-spacing: 0.03em;" if use_inline_styles else "" %}
-{% set tag_list_style = "list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 8px;" if use_inline_styles else "" %}
-{% set tag_badge_base_style = "display: inline-flex; align-items: center; padding: 6px 12px; border-radius: 999px; font-size: 12px; letter-spacing: 0.03em; border: 1px solid rgba(148, 163, 184, 0.25);" if use_inline_styles else "" %}
-{% set timeline_style = "list-style: none; margin: 24px 0 0; padding: 0 0 0 20px; border-left: 2px solid " ~ timeline_border ~ "; display: grid; gap: 24px;" if use_inline_styles else "" %}
+{% set tag_list_style = "list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 6px;" if use_inline_styles else "" %}
+{% set timeline_style = "list-style: none; margin: 20px 0 0; padding: 0 0 0 20px; border-left: 2px solid " ~ timeline_border ~ "; display: grid; gap: 20px;" if use_inline_styles else "" %}
 {% set timeline_item_style = "position: relative; padding-left: 24px;" if use_inline_styles else "" %}
 {% set timeline_marker_style = "position: absolute; left: -12px; top: 8px; width: 10px; height: 10px; border-radius: 50%; background: " ~ accent_color ~ "; box-shadow: 0 0 0 6px rgba(56, 189, 248, 0.18);" if use_inline_styles else "" %}
-{% set timeline_content_style = "background: " ~ timeline_surface ~ "; border: 1px solid " ~ timeline_border ~ "; border-radius: 16px; padding: 16px; color: " ~ text_color ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
-{% set timeline_meta_style = "display: flex; flex-wrap: wrap; gap: 8px 16px; font-size: 13px; color: " ~ muted_color ~ "; margin: 0 0 8px;" if use_inline_styles else "" %}
-{% set timeline_body_style = "margin: 0 0 8px 0; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
+{% set timeline_content_style = "background: " ~ timeline_surface ~ "; border: 1px solid " ~ timeline_border ~ "; border-radius: 16px; padding: 14px; color: " ~ text_color ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
+{% set timeline_meta_style = "display: flex; flex-wrap: wrap; gap: 6px 14px; font-size: 13px; color: " ~ muted_color ~ "; margin: 0 0 6px;" if use_inline_styles else "" %}
+{% set timeline_body_style = "margin: 0 0 6px 0; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
 {% set timeline_body_last_style = "margin: 0; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
 {% if not use_inline_styles %}
 <style>
@@ -94,7 +96,7 @@
     color: var(--clipboard-text, #0f172a);
     border-radius: 1.75rem;
     border: 1px solid var(--clipboard-border, rgba(148, 163, 184, 0.32));
-    padding: 2rem;
+    padding: 1.5rem;
     box-sizing: border-box;
     width: 100%;
     line-height: 1.6;
@@ -113,10 +115,10 @@
   .ticket-clipboard-summary header {
     display: flex;
     justify-content: space-between;
-    gap: 1.5rem;
+    gap: 1.25rem;
     align-items: flex-start;
-    margin-bottom: 1.75rem;
-    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    padding: 1.25rem;
     border-radius: 1.5rem;
     background: var(--clipboard-surface-strong, rgba(255, 255, 255, 0.88));
     border: 1px solid var(--clipboard-border, rgba(148, 163, 184, 0.32));
@@ -126,7 +128,7 @@
   .ticket-clipboard-summary .summary-title-group {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.625rem;
   }
 
   .ticket-clipboard-summary .summary-title {
@@ -139,15 +141,15 @@
   .ticket-clipboard-summary .summary-timestamps {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0.25rem;
     font-size: 0.8rem;
     color: var(--clipboard-muted, #475569);
     text-align: right;
   }
 
   .ticket-clipboard-summary .summary-section {
-    margin-top: 1.75rem;
-    padding: 1.5rem;
+    margin-top: 1.5rem;
+    padding: 1.25rem;
     border-radius: 1.5rem;
     background: var(--clipboard-surface, rgba(255, 255, 255, 0.86));
     border: 1px solid var(--clipboard-border, rgba(148, 163, 184, 0.32));
@@ -155,7 +157,7 @@
   }
 
   .ticket-clipboard-summary .summary-section h2 {
-    margin: 0 0 0.75rem;
+    margin: 0 0 0.625rem;
     font-size: 0.75rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -173,7 +175,7 @@
   }
 
   .ticket-clipboard-summary .summary-table th {
-    padding: 0.35rem 0;
+    padding: 0.3rem 0;
     width: 32%;
     font-size: 0.75rem;
     text-transform: uppercase;
@@ -183,7 +185,7 @@
   }
 
   .ticket-clipboard-summary .summary-table td {
-    padding: 0.35rem 0;
+    padding: 0.3rem 0;
     color: var(--clipboard-text, #0f172a);
     vertical-align: top;
   }
@@ -246,28 +248,30 @@
     list-style: none;
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
+    gap: 0.375rem;
     margin: 0;
     padding: 0;
   }
 
-  .ticket-clipboard-summary .summary-tags li {
-    padding: 0.35rem 0.65rem;
-    border-radius: 999px;
-    font-size: 0.75rem;
-    letter-spacing: 0.03em;
+  .ticket-clipboard-summary .summary-tags .badge {
+    padding: 0.375rem 0.875rem;
+  }
+
+  .ticket-clipboard-summary .summary-tags .tag-badge {
     background: var(--tag-color, rgba(30, 41, 59, 0.85));
-    color: var(--tag-text, #0f172a);
-    border: 1px solid rgba(148, 163, 184, 0.25);
+    color: var(--tag-text, #e2e8f0);
+    text-transform: none;
+    letter-spacing: 0.04em;
+    font-size: 0.75rem;
   }
 
   .ticket-clipboard-summary .summary-timeline {
     list-style: none;
-    margin: 1.5rem 0 0;
+    margin: 1.25rem 0 0;
     padding: 0 0 0 1.25rem;
     border-left: 2px solid var(--clipboard-timeline-border, rgba(148, 163, 184, 0.28));
     display: grid;
-    gap: 1.5rem;
+    gap: 1.25rem;
   }
 
   .ticket-clipboard-summary .summary-timeline li {
@@ -290,7 +294,7 @@
     background: var(--clipboard-timeline-surface, rgba(255, 255, 255, 0.92));
     border: 1px solid var(--clipboard-timeline-border, rgba(148, 163, 184, 0.28));
     border-radius: 1rem;
-    padding: 1rem;
+    padding: 0.875rem;
     color: var(--clipboard-text, #0f172a);
     box-shadow: var(--clipboard-shadow, 0 18px 40px rgba(15, 23, 42, 0.08));
   }
@@ -298,14 +302,14 @@
   .ticket-clipboard-summary .timeline-meta {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem 1rem;
+    gap: 0.375rem 0.875rem;
     font-size: 0.8rem;
     color: var(--clipboard-muted, #475569);
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.375rem;
   }
 
   .ticket-clipboard-summary .timeline-body {
-    margin: 0;
+    margin: 0 0 0.375rem 0;
     color: var(--clipboard-text, #0f172a);
   }
 
@@ -450,9 +454,14 @@
         <ul class="summary-tags"{% if tag_list_style %} style="{{ tag_list_style }}"{% endif %}>
           {% for tag in ticket.tags %}
             {% set tag_background = tag.color or config.colors.tags.get('background', '#1e293b') %}
-            {% set tag_variable_style = '--tag-color: ' ~ tag_background ~ '; --tag-text: ' ~ tag_text_color ~ ';' %}
-            {% set tag_style_value = tag_variable_style + (' ' + tag_badge_base_style + ' background: ' + tag_background + '; color: ' + tag_text_color + ';' if tag_badge_base_style else '') %}
-            <li style="{{ tag_style_value }}">
+            {% set tag_text = (tag.text_color if tag.text_color is defined and tag.text_color) or tag_text_color %}
+            {% set tag_variable_style = '--tag-color: ' ~ tag_background ~ '; --tag-text: ' ~ tag_text ~ ';' %}
+            {% set tag_style_value = tag_variable_style + (
+              ' ' + badge_base_style + ' background: ' + tag_background + '; color: ' + tag_text + '; padding: 6px 14px; font-size: 12px; letter-spacing: 0.04em; text-transform: none;'
+              if badge_base_style else
+              ' display: inline-flex; align-items: center; justify-content: center; padding: 6px 14px; border-radius: 999px; font-size: 12px; font-weight: 600; text-transform: none; letter-spacing: 0.04em; white-space: nowrap; box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12); border: 1px solid rgba(148, 163, 184, 0.35); background: ' + tag_background + '; color: ' + tag_text + ';'
+            ) %}
+            <li class="badge tag-badge" style="{{ tag_style_value }}">
               {{ tag.name }}
             </li>
           {% endfor %}


### PR DESCRIPTION
## Summary
- ensure the clipboard summary article always applies its gradient inline and tighten the header/section/timeline spacing
- reuse the badge styling for tags with an improved text color fallback and inline overrides
- refresh the stylesheet fallback so section spacing and tag appearance stay consistent without inline styles

## Testing
- `pytest` *(fails: tests/test_settings.py::test_settings_update_persists_between_app_starts asserts auto_return_to_list should be true)*

------
https://chatgpt.com/codex/tasks/task_e_68fa1fe305b0832c953ea55ad030283f