### PR TITLE
Style SLA stage inputs for responsive layout

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1013,6 +1013,49 @@ body.compact .filter-fields .filter-actions {
   border-color: rgba(56, 189, 248, 0.6);
 }
 
+.sla-stage-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sla-stage-inputs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.sla-stage-input {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 1 1 10rem;
+}
+
+.sla-stage-input .stage-label {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.9);
+  white-space: nowrap;
+}
+
+.sla-stage-input input[type="number"] {
+  flex: 0 0 6rem;
+  max-width: 6rem;
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  .sla-stage-input {
+    flex: 1 1 100%;
+    justify-content: space-between;
+  }
+
+  .sla-stage-input input[type="number"] {
+    flex-basis: 5rem;
+    max-width: 5rem;
+  }
+}
+
 .field-group.split {
   display: grid;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- apply flex layout to SLA stage controls so labels and inputs align horizontally
- limit numeric field width and add responsive behavior to keep the stage inputs on one row by default

## Testing
- `pytest` *(fails: tests/test_settings.py::test_settings_update_persists_between_app_starts)*

------
https://chatgpt.com/codex/tasks/task_e_68fa229cdb2c832cbeb341589fc7c103