### PR TITLE
Improve ticket tooltip pointer positioning

### DIFF
--- a/static/css/ticket-tooltips.css
+++ b/static/css/ticket-tooltips.css
@@ -3,10 +3,11 @@
 }
 
 .ticket-card .ticket-tooltip {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  width: min(22rem, calc(100% - 2rem));
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: min(22rem, calc(100vw - 2rem));
+  max-width: min(22rem, calc(100vw - 2rem));
   background: color-mix(in srgb, rgba(15, 23, 42, 0.94) 88%, var(--ticket-accent, rgba(56, 189, 248, 0.3)) 12%);
   border: 1px solid color-mix(in srgb, var(--ticket-accent, rgba(56, 189, 248, 0.45)) 55%, transparent 45%);
   border-radius: 1.25rem;
@@ -144,10 +145,8 @@
 
 @media (max-width: 720px) {
   .ticket-card .ticket-tooltip {
-    position: fixed;
-    inset: auto 1.5rem 2rem 1.5rem;
-    width: auto;
-    max-width: min(28rem, calc(100vw - 3rem));
+    width: min(24rem, calc(100vw - 2rem));
+    max-width: min(24rem, calc(100vw - 2rem));
   }
 }
 


### PR DESCRIPTION
## Summary
- track pointer movement in the ticket tooltip controller, waiting for a stationary pointer before opening and positioning the overlay near the cursor while keeping it inside the viewport
- provide trigger-based fallback positioning when opening via focus or when pointer coordinates are unavailable so keyboard interactions remain accessible
- switch the tooltip container styling to fixed positioning with dynamic coordinates while preserving transitions and pointer-event behaviour

## Testing
- pytest *(fails: tests/test_settings.py::test_settings_update_persists_between_app_starts expects `auto_return_to_list` to persist as True, but the POST payload in the test does not include that field so the setting remains False)*
- python -m py_compile $(git ls-files '*.py')


------
https://chatgpt.com/codex/tasks/task_e_68fa22b60d54832c9107a56cffa29a3b