### PR TITLE
Align SLA default due days control with inline layout

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -379,6 +379,14 @@ body.compact .field-group {
   gap: 0.4rem;
 }
 
+body.compact .field-group--inline {
+  gap: 0.75rem;
+}
+
+body.compact .field-group--inline .field-group__meta {
+  gap: 0.3rem;
+}
+
 body.compact .field-group label {
   font-size: 0.8rem;
 }
@@ -388,6 +396,12 @@ body.compact .field-group textarea,
 body.compact .field-group select {
   padding: 0.65rem 0.9rem;
   border-radius: 0.65rem;
+}
+
+@media (min-width: 768px) {
+  body.compact .field-group--inline .field-group__control > * {
+    max-width: 8rem;
+  }
 }
 
 body.compact .field-group.split {
@@ -986,6 +1000,30 @@ body.compact .filter-fields .filter-actions {
   gap: 0.5rem;
 }
 
+.field-group--inline {
+  display: grid;
+  gap: 1rem;
+  align-items: start;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.field-group--inline .field-group__meta {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.4rem;
+  align-items: flex-start;
+}
+
+.field-group--inline .field-group__control {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.field-group--inline .field-group__control > * {
+  width: 100%;
+}
+
 .field-group label {
   font-size: 0.85rem;
   letter-spacing: 0.03em;
@@ -1011,6 +1049,22 @@ body.compact .filter-fields .filter-actions {
 .field-group select:focus {
   outline: 2px solid rgba(56, 189, 248, 0.4);
   border-color: rgba(56, 189, 248, 0.6);
+}
+
+@media (min-width: 768px) {
+  .field-group--inline {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    align-items: center;
+  }
+
+  .field-group--inline .field-group__control {
+    align-self: stretch;
+    justify-content: flex-end;
+  }
+
+  .field-group--inline .field-group__control > * {
+    max-width: 10rem;
+  }
 }
 
 .sla-stage-group {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -74,18 +74,23 @@
           fall back to defaults.
         </p>
 
-        <div class="field-group">
-          <label for="default_due_days">Default backlog due days</label>
-          <input
-            type="number"
-            id="default_due_days"
-            name="default_due_days"
-            min="0"
-            value="{{ form.default_due_days|default('') }}"
-          />
-          <p class="help">
-            Used when a priority does not specify custom backlog stage thresholds.
-          </p>
+        <div class="field-group field-group--inline">
+          <div class="field-group__meta">
+            <label for="default_due_days">Default backlog due days</label>
+            <p class="help" id="default_due_days_help">
+              Used when a priority does not specify custom backlog stage thresholds.
+            </p>
+          </div>
+          <div class="field-group__control">
+            <input
+              type="number"
+              id="default_due_days"
+              name="default_due_days"
+              min="0"
+              value="{{ form.default_due_days|default('') }}"
+              aria-describedby="default_due_days_help"
+            />
+          </div>
         </div>
 
         <div class="sla-stage-group">


### PR DESCRIPTION
## Summary
- restructure the default backlog due days setting into an inline field container that groups the help copy with its label
- add grid and flex styling, including compact-mode tweaks, so the description column stacks help above the label while the input stays aligned in the second column

## Testing
- pytest *(fails: tests/test_settings.py::test_settings_update_persists_between_app_starts — pre-existing failure where auto_return_to_list stays false without a submitted value)*

------
https://chatgpt.com/codex/tasks/task_e_68fa24834cb0832ca175fd5b1dfc9d9b