### PR TITLE
Align clipboard updates limit layout with SLA field

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1014,6 +1014,11 @@ body.compact .filter-fields .filter-actions {
   align-items: flex-start;
 }
 
+.field-group--inline .field-group__meta,
+.field-group--inline .field-group__control {
+  min-width: 0;
+}
+
 .field-group--inline .field-group__control {
   display: flex;
   align-items: center;

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -249,16 +249,23 @@
         </table>
       </fieldset>
 
-      <div class="field-group">
-        <label for="updates_limit">Clipboard updates limit</label>
-        <input
-          type="number"
-          id="updates_limit"
-          name="updates_limit"
-          min="0"
-          value="{{ form.updates_limit|default('') }}"
-        />
-        <p class="help">Limit the number of recent updates included in clipboard exports.</p>
+      <div class="field-group field-group--inline">
+        <div class="field-group__meta">
+          <label for="updates_limit">Clipboard updates limit</label>
+          <p class="help" id="updates_limit_help">
+            Limit the number of recent updates included in clipboard exports.
+          </p>
+        </div>
+        <div class="field-group__control">
+          <input
+            type="number"
+            id="updates_limit"
+            name="updates_limit"
+            min="0"
+            value="{{ form.updates_limit|default('') }}"
+            aria-describedby="updates_limit_help"
+          />
+        </div>
       </div>
 
       <div class="field-group checkbox">


### PR DESCRIPTION
## Summary
- restructure the clipboard updates limit field in settings.html to use the same inline layout as the backlog due days control
- extend the shared inline field helper styles so both controls have matching sizing behaviour

## Testing
- `pytest` *(fails: tests/test_settings.py::test_settings_update_persists_between_app_starts - assert False is True; reproduces on main)*

------
https://chatgpt.com/codex/tasks/task_e_68fa2718be04832c95b4f2d956c19350