### PR TITLE
Wrap long URLs in compact tooltip links

### DIFF
--- a/static/css/ticket-tooltips.css
+++ b/static/css/ticket-tooltips.css
@@ -131,6 +131,17 @@
   text-decoration: none;
 }
 
+.ticket-tooltip__links a,
+.ticket-tooltip__links span {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.ticket-tooltip__links span {
+  color: var(--ticket-title-color, #f8fafc);
+  font-weight: 500;
+}
+
 .ticket-tooltip__attachments a:hover,
 .ticket-tooltip__attachments a:focus-visible,
 .ticket-tooltip__links a:hover,


### PR DESCRIPTION
## Summary
- allow ticket tooltips to wrap very long link labels within the compact card width
- apply the same wrapping and emphasis styles to fallback span entries without hrefs

## Testing
- pytest *(fails: tests/test_settings.py::test_settings_update_persists_between_app_starts expects `auto_return_to_list` to remain enabled without the checkbox field in the POST payload)*

------
https://chatgpt.com/codex/tasks/task_e_68fa297b2454832ca7008b21b5f0ae5b