### PR TITLE
Add SLA stage name helper

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -146,6 +146,7 @@ def test_settings_update_persists_between_app_starts(tmp_path):
                 ("text_sections", "updates"),
                 ("updates_limit", "3"),
                 ("demo_mode", "on"),
+                ("auto_return_to_list", "on"),
             ]
         ),
         follow_redirects=True,


### PR DESCRIPTION
## Summary
- add a helper that returns descriptive SLA stage labels with a fallback for extra stages
- use the helper when rendering gradient palette entries and SLA stage headers in the settings view
- ensure the settings persistence test posts the auto-return toggle along with other configuration fields

## Testing
- pytest
- python -m compileall tickettracker tests

------
https://chatgpt.com/codex/tasks/task_e_68fa29ef8a10832cb3865f078602063c