### PR TITLE
Prevent tooltip hover from retriggering tooltip

### DIFF
--- a/static/js/ticket-tooltips.js
+++ b/static/js/ticket-tooltips.js
@@ -213,6 +213,15 @@ class TicketTooltipController {
     return Array.from(this.tooltip.querySelectorAll(selectors.join(',')));
   }
 
+  isPointerWithinTriggerBounds() {
+    if (!this.pointerPosition) {
+      return false;
+    }
+    const rect = this.trigger.getBoundingClientRect();
+    const { x, y } = this.pointerPosition;
+    return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+  }
+
   startPointerTracking(event) {
     if (event && typeof event.pointerId === 'number') {
       this.activePointerId = event.pointerId;
@@ -272,6 +281,9 @@ class TicketTooltipController {
   handlePointerStationary() {
     this.pointerStationaryTimeout = null;
     if (!this.hovering) {
+      return;
+    }
+    if (this.pointerPosition && !this.isPointerWithinTriggerBounds()) {
       return;
     }
     if (!this.pointerPosition) {


### PR DESCRIPTION
## Summary
- add a helper to detect when the pointer is still within the ticket trigger bounds
- skip tooltip reopen/reposition logic when the pointer is stationary outside the trigger

## Testing
- pytest *(fails: tests/test_settings.py::test_settings_update_persists_between_app_starts))*

------
https://chatgpt.com/codex/tasks/task_e_68fa2cd50478832c84d91a8a290b4898