### PR TITLE
Correct SLA zone threshold ordering

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -146,6 +146,7 @@ def test_settings_update_persists_between_app_starts(tmp_path):
                 ("text_sections", "updates"),
                 ("updates_limit", "3"),
                 ("demo_mode", "on"),
+                ("auto_return_to_list", "on"),
             ]
         ),
         follow_redirects=True,

--- a/tests/test_ticket_colors.py
+++ b/tests/test_ticket_colors.py
@@ -1,0 +1,83 @@
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from flask import current_app
+
+from tickettracker.app import create_app
+from tickettracker.config import DEFAULT_CONFIG, GRADIENT_STAGE_ORDER
+from tickettracker.views.tickets import _compute_ticket_color
+
+
+def _write_config(target: Path, data: dict) -> Path:
+    target.write_text(json.dumps(data, indent=2))
+    return target
+
+
+def _default_config() -> dict:
+    return json.loads(json.dumps(DEFAULT_CONFIG))
+
+
+def _resolve_stage_index(config, color: str) -> int | None:
+    normalized = color.upper()
+    for index, key in enumerate(GRADIENT_STAGE_ORDER):
+        stage_color = config.colors.gradient_color(key)
+        if stage_color.upper() == normalized:
+            return index
+    overdue_color = config.colors.gradient_overdue_color()
+    if overdue_color.upper() == normalized:
+        return len(GRADIENT_STAGE_ORDER)
+    return None
+
+
+def _stage_for_days(config, days_out: float) -> int | None:
+    now = datetime.utcnow()
+    ticket = SimpleNamespace(
+        due_date=now + timedelta(days=days_out),
+        created_at=None,
+        age_reference_date=None,
+        priority="Low",
+        status=None,
+    )
+    color = _compute_ticket_color(ticket, config)
+    return _resolve_stage_index(config, color)
+
+
+def test_due_stage_thresholds_follow_zone_labels(tmp_path):
+    config_data = _default_config()
+    config_path = _write_config(tmp_path / "config.json", config_data)
+    app = create_app(config_path)
+
+    with app.app_context():
+        config = current_app.config["APP_CONFIG"]
+
+        assert config.sla.due_thresholds() == [7, 14, 21, 28]
+
+        assert _stage_for_days(config, 35) == 0
+        assert _stage_for_days(config, 24) == 0
+        assert _stage_for_days(config, 19) == 1
+        assert _stage_for_days(config, 12) == 2
+        assert _stage_for_days(config, 6) == 3
+
+
+def test_due_stage_thresholds_sort_unsorted_values(tmp_path):
+    config_data = _default_config()
+    config_data.setdefault("sla", {})["due_stage_days"] = [30, 10, 20, 5]
+    config_path = _write_config(tmp_path / "config.json", config_data)
+    app = create_app(config_path)
+
+    with app.app_context():
+        config = current_app.config["APP_CONFIG"]
+
+        assert config.sla.due_thresholds() == [5, 10, 20, 30]
+
+        assert _stage_for_days(config, 32) == 0
+        assert _stage_for_days(config, 18) == 1
+        assert _stage_for_days(config, 9) == 2
+        assert _stage_for_days(config, 4) == 3

--- a/tickettracker/config.py
+++ b/tickettracker/config.py
@@ -142,11 +142,16 @@ class SLAConfig:
     default_due_days: Optional[int] = DEFAULT_BACKLOG_DUE_DAYS
 
     def due_thresholds(self) -> List[int]:
-        """Return descending day thresholds for due-date staging."""
+        """Return ascending day thresholds for due-date staging."""
 
         thresholds = [day for day in self.due_stage_days if isinstance(day, int)]
-        thresholds.sort(reverse=True)
-        return thresholds or list(DEFAULT_DUE_STAGE_DAYS)
+        thresholds.sort()
+        if thresholds:
+            return thresholds
+
+        fallback = [day for day in DEFAULT_DUE_STAGE_DAYS if isinstance(day, int)]
+        fallback.sort()
+        return fallback
 
     def priority_thresholds(self, priority: str) -> List[int]:
         """Return ascending day thresholds for backlog staging by priority."""

--- a/tickettracker/views/tickets.py
+++ b/tickettracker/views/tickets.py
@@ -125,9 +125,10 @@ def _compute_ticket_color(
         if not thresholds:
             return config.colors.gradient_stage_color(0)
         for index, threshold in enumerate(thresholds):
-            if days_remaining > threshold:
-                return config.colors.gradient_stage_color(index)
-        return config.colors.gradient_stage_color(len(thresholds) - 1)
+            if days_remaining <= threshold:
+                stage_index = len(thresholds) - index - 1
+                return config.colors.gradient_stage_color(stage_index)
+        return config.colors.gradient_stage_color(0)
 
     reference_date = ticket.age_reference_date or (
         ticket.created_at.date() if ticket.created_at else now.date()


### PR DESCRIPTION
## Summary
- ensure SLA due date thresholds are normalized to ascending order with a sorted fallback
- update ticket color selection to map days remaining to the matching stage label using those ascending thresholds
- add regression tests that confirm due-date ranges align with the new stage names and handle unsorted configuration values

## Testing
- pytest
- python -m compileall tickettracker tests

------
https://chatgpt.com/codex/tasks/task_e_68fa29ef8a10832cb3865f078602063c