### PR TITLE
Clarify SLA due date stage ordering

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -96,8 +96,8 @@
         <div class="sla-stage-group">
           <h3>Due date stages</h3>
           <p class="help">
-            Days remaining before a ticket advances through warning stages (highest stage
-            first).
+            Days remaining before a ticket advances through warning stages, listed from the
+            lowest stage (Comfort Zone) through the highest stage (Fire Zone).
           </p>
           <div class="sla-stage-inputs">
             {% for label in sla_stage_labels %}


### PR DESCRIPTION
## Summary
- clarify the due date stage help text to describe the Comfort-to-Fire ordering
- ensure the SLA section copy no longer references highest-stage-first ordering

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68fa3a144660832c8c9f713d2d3db320