### PR TITLE
Switch settings palette to single color chip inputs

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1160,13 +1160,13 @@ body.compact .filter-fields .filter-actions {
 .color-settings .color-palette {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .color-section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .color-section h3 {
@@ -1175,72 +1175,90 @@ body.compact .filter-fields .filter-actions {
   color: #f8fafc;
 }
 
-.color-section-grid {
-  display: grid;
+.color-section-heading {
+  display: flex;
+  align-items: center;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.color-entry {
-  background: rgba(15, 23, 42, 0.45);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  border-radius: 0.75rem;
-  padding: 0.75rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-}
-
-.color-entry-label {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  font-size: 0.9rem;
-  color: rgba(248, 250, 252, 0.9);
-}
-
-.color-chip {
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.6) inset;
-}
-
-.color-entry-inputs {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
   flex-wrap: wrap;
 }
 
-.color-entry-inputs input[type="color"] {
-  border: none;
-  padding: 0;
-  width: 3rem;
-  height: 2.25rem;
-  background: transparent;
-  cursor: pointer;
+.color-section-columns {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.color-entry-inputs input[type="color"]::-webkit-color-swatch-wrapper {
-  padding: 0;
+
+.color-section-grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.color-entry-inputs input[type="color"]::-webkit-color-swatch {
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 0.5rem;
-}
-
-.color-entry-inputs input[type="color"]::-moz-color-swatch {
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 0.5rem;
-}
-
-.color-hex-input {
-  flex: 1 1 8ch;
+.color-chip-field {
+  --chip-color: rgba(148, 163, 184, 0.4);
+  display: block;
+  position: relative;
+  border-radius: 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--chip-color) 40%, rgba(148, 163, 184, 0.2));
+  background: color-mix(in srgb, var(--chip-color) 18%, rgba(15, 23, 42, 0.92));
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   min-width: 0;
+}
+
+.color-chip-field:hover {
+  border-color: color-mix(in srgb, var(--chip-color) 55%, rgba(148, 163, 184, 0.38));
+  background: color-mix(in srgb, var(--chip-color) 24%, rgba(15, 23, 42, 0.92));
+}
+
+.color-chip-field:focus-within {
+  border-color: color-mix(in srgb, var(--chip-color) 65%, var(--accent) 55%);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--chip-color) 20%, var(--accent) 55%, transparent 45%);
+}
+
+.color-chip-control {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.75rem 0.9rem;
+  width: 100%;
+  cursor: pointer;
+  border-radius: inherit;
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.color-chip-control__swatch {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  background: var(--chip-color);
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.6) inset;
+  border: 1px solid rgba(15, 23, 42, 0.55);
+  flex-shrink: 0;
+}
+
+.color-chip-control__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.color-chip-control__label {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.color-chip-control__value {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: color-mix(in srgb, var(--chip-color) 18%, var(--text-muted));
+}
+
+.color-chip-control__input {
+  position: absolute;
 }
 
 .tag-mode {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -160,41 +160,104 @@
       <fieldset class="field-group color-settings">
         <legend>Colors</legend>
         <p class="help">
-          Customize the ticket palette. Leave a hex value blank to restore the default
-          color.
+          Customize the ticket palette. Select a chip to pick a new color or choose the
+          default shade again to restore it.
         </p>
+        {% set palette = namespace(ticket=None, columns=[], remainder=[]) %}
+        {% for section in color_sections %}
+          {% if section.name == 'ticket_title' %}
+            {% set palette.ticket = section %}
+          {% elif section.name in ['gradient', 'statuses', 'priorities'] %}
+            {% set palette.columns = palette.columns + [section] %}
+          {% else %}
+            {% set palette.remainder = palette.remainder + [section] %}
+          {% endif %}
+        {% endfor %}
         <div class="color-palette">
-          {% for section in color_sections %}
-            <div class="color-section">
+          {% if palette.ticket and palette.ticket.entries %}
+            {% set ticket_entry = palette.ticket.entries[0] %}
+            {% set key_slug = ticket_entry.key|lower|replace(' ', '-')|replace('/', '-')|replace('[', '-')|replace(']', '-') %}
+            {% set input_id = 'color_%s_%s' | format(palette.ticket.name, key_slug) %}
+            <div class="color-section color-section--ticket">
+              <div class="color-section-heading">
+                <h3>{{ palette.ticket.label }}</h3>
+                <div class="color-chip-field" style="--chip-color: {{ ticket_entry.value or ticket_entry.default }};">
+                  <input
+                    type="color"
+                    class="sr-only color-chip-control__input"
+                    id="{{ input_id }}"
+                    name="{{ ticket_entry.field_name }}"
+                    value="{{ ticket_entry.value or ticket_entry.default }}"
+                    aria-label="{{ ticket_entry.label }} color"
+                  />
+                  <label class="color-chip-control" for="{{ input_id }}" title="{{ ticket_entry.label }} ({{ ticket_entry.value or ticket_entry.default }})">
+                    <span class="color-chip-control__swatch" aria-hidden="true"></span>
+                    <span class="color-chip-control__meta">
+                      <span class="color-chip-control__label">{{ ticket_entry.label }}</span>
+                      <span class="color-chip-control__value">{{ ticket_entry.value or ticket_entry.default }}</span>
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          {% endif %}
+
+          {% if palette.columns %}
+            <div class="color-section-columns">
+              {% for section in palette.columns %}
+                <div class="color-section color-section--{{ section.name }}">
+                  <h3>{{ section.label }}</h3>
+                  <div class="color-section-grid">
+                    {% for entry in section.entries %}
+                      {% set key_slug = entry.key|lower|replace(' ', '-')|replace('/', '-')|replace('[', '-')|replace(']', '-') %}
+                      {% set input_id = 'color_%s_%s' | format(section.name, key_slug) %}
+                      <div class="color-chip-field" style="--chip-color: {{ entry.value or entry.default }};">
+                        <input
+                          type="color"
+                          class="sr-only color-chip-control__input"
+                          id="{{ input_id }}"
+                          name="{{ entry.field_name }}"
+                          value="{{ entry.value or entry.default }}"
+                          aria-label="{{ entry.label }} color"
+                        />
+                        <label class="color-chip-control" for="{{ input_id }}" title="{{ entry.label }} ({{ entry.value or entry.default }})">
+                          <span class="color-chip-control__swatch" aria-hidden="true"></span>
+                          <span class="color-chip-control__meta">
+                            <span class="color-chip-control__label">{{ entry.label }}</span>
+                            <span class="color-chip-control__value">{{ entry.value or entry.default }}</span>
+                          </span>
+                        </label>
+                      </div>
+                    {% endfor %}
+                  </div>
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
+
+          {% for section in palette.remainder %}
+            <div class="color-section color-section--{{ section.name }}">
               <h3>{{ section.label }}</h3>
               <div class="color-section-grid">
                 {% for entry in section.entries %}
                   {% set key_slug = entry.key|lower|replace(' ', '-')|replace('/', '-')|replace('[', '-')|replace(']', '-') %}
-                  {% set input_id = "color_%s_%s" | format(section.name, key_slug) %}
-                  <div class="color-entry">
-                    <div class="color-entry-label">
-                      <span class="color-chip" style="background-color: {{ entry.value }}" aria-hidden="true"></span>
-                      <span>{{ entry.label }}</span>
-                    </div>
-                    <div class="color-entry-inputs">
-                      <input
-                        type="color"
-                        id="{{ input_id }}"
-                        name="{{ entry.field_name }}"
-                        value="{{ entry.value }}"
-                        aria-label="{{ entry.label }} color"
-                      />
-                      <input
-                        type="text"
-                        class="color-hex-input"
-                        name="{{ entry.text_field_name }}"
-                        value="{{ entry.text }}"
-                        placeholder="{{ entry.default }}"
-                        pattern="#?[0-9a-fA-F]{3}([0-9a-fA-F]{3})?"
-                        title="Enter a hex color like #AABBCC or #ABC"
-                        aria-label="{{ entry.label }} hex value"
-                      />
-                    </div>
+                  {% set input_id = 'color_%s_%s' | format(section.name, key_slug) %}
+                  <div class="color-chip-field" style="--chip-color: {{ entry.value or entry.default }};">
+                    <input
+                      type="color"
+                      class="sr-only color-chip-control__input"
+                      id="{{ input_id }}"
+                      name="{{ entry.field_name }}"
+                      value="{{ entry.value or entry.default }}"
+                      aria-label="{{ entry.label }} color"
+                    />
+                    <label class="color-chip-control" for="{{ input_id }}" title="{{ entry.label }} ({{ entry.value or entry.default }})">
+                      <span class="color-chip-control__swatch" aria-hidden="true"></span>
+                      <span class="color-chip-control__meta">
+                        <span class="color-chip-control__label">{{ entry.label }}</span>
+                        <span class="color-chip-control__value">{{ entry.value or entry.default }}</span>
+                      </span>
+                    </label>
                   </div>
                 {% endfor %}
               </div>

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -272,20 +272,17 @@ def test_update_color_palette(tmp_path):
     payload = _settings_form_data(config_data)
     payload.update(
         {
-            "colors_hex[ticket_title]": "ddeeff",
-            "colors_hex[gradient][stage0]": "#112233",
-            "colors_hex[gradient][stage1]": "#223344",
-            "colors_hex[gradient][stage2]": "",
-            "colors_hex[gradient][stage3]": "#556677",
-            "colors_hex[gradient][overdue]": "#778899",
-            "colors_hex[statuses][resolved]": "336699",
-            "colors_hex[statuses][on_hold]": "",
-            "colors_hex[priorities][Low]": "",
-            "colors_hex[priorities][Medium]": "#00aa00",
-            "colors_hex[priorities][High]": "#abc",
-            "colors_hex[priorities][Critical]": "#123456",
-            "colors_hex[tags][background]": "#010203",
-            "colors_hex[tags][text]": "#fefefe",
+            "colors[ticket_title]": "#ddeeff",
+            "colors[gradient][stage0]": "#112233",
+            "colors[gradient][stage1]": "#223344",
+            "colors[gradient][stage3]": "#556677",
+            "colors[gradient][overdue]": "#778899",
+            "colors[statuses][resolved]": "#336699",
+            "colors[priorities][Medium]": "#00aa00",
+            "colors[priorities][High]": "#abc",
+            "colors[priorities][Critical]": "#123456",
+            "colors[tags][background]": "#010203",
+            "colors[tags][text]": "#fefefe",
         }
     )
 

--- a/tickettracker/views/settings.py
+++ b/tickettracker/views/settings.py
@@ -288,7 +288,6 @@ def _color_category_entries(
                         "label": "Ticket title",
                         "entry": ticket_entry,
                         "field_name": "colors[ticket_title]",
-                        "text_field_name": "colors_hex[ticket_title]",
                     }
                 ],
             )
@@ -334,7 +333,6 @@ def _color_category_entries(
                 "label": label,
                 "entry": entry,
                 "field_name": f"colors[gradient][{key}]",
-                "text_field_name": f"colors_hex[gradient][{key}]",
             }
         )
     if gradient_entries:
@@ -358,7 +356,6 @@ def _color_category_entries(
                 "label": label,
                 "entry": entry,
                 "field_name": f"colors[statuses][{key}]",
-                "text_field_name": f"colors_hex[statuses][{key}]",
             }
         )
     if status_entries:
@@ -379,7 +376,6 @@ def _color_category_entries(
                 "label": str(key),
                 "entry": entry,
                 "field_name": f"colors[priorities][{key}]",
-                "text_field_name": f"colors_hex[priorities][{key}]",
             }
         )
     if priority_entries:
@@ -403,7 +399,6 @@ def _color_category_entries(
                 "label": label,
                 "entry": entry,
                 "field_name": f"colors[tags][{key}]",
-                "text_field_name": f"colors_hex[tags][{key}]",
             }
         )
     if tag_entries:
@@ -425,27 +420,20 @@ def _process_color_entry(
 
     default_value = str(entry.get("default", entry.get("value", "")))
     field_name = str(entry_info.get("field_name", ""))
-    text_field_name = str(entry_info.get("text_field_name", ""))
-
     color_value = str(form_data.get(field_name, "")).strip()
-    text_value = str(form_data.get(text_field_name, "")).strip()
-    chosen_value = text_value or color_value
 
-    if not chosen_value:
+    if not color_value:
         entry["value"] = default_value
-        entry["text"] = ""
         return
 
-    normalized = normalize_hex_color(chosen_value)
+    normalized = normalize_hex_color(color_value)
     if normalized is None:
-        entry["text"] = chosen_value
         entry.setdefault("value", default_value)
         label = str(entry_info.get("label", "color"))
         invalid_labels.append(label)
         return
 
     entry["value"] = normalized
-    entry["text"] = normalized
 
 
 def _color_sections(
@@ -465,10 +453,8 @@ def _color_sections(
                     "key": entry_info["key"],
                     "label": entry_info["label"],
                     "value": entry.get("value", entry.get("default")),
-                    "text": entry.get("text", entry.get("value")),
                     "default": entry.get("default", entry.get("value")),
                     "field_name": entry_info["field_name"],
-                    "text_field_name": entry_info["text_field_name"],
                 }
             )
         if section_entries:


### PR DESCRIPTION
## Summary
- replace the settings color palette form with chip-based color pickers and a multi-column layout
- simplify the palette parsing helpers to rely solely on `colors[...]` form fields
- adjust CSS for the new controls and update tests to match the revised field names

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68fa3ba9a530832cadbf6d2608a22cbe