### PR TITLE
Add demo dataset persistence controls

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -431,6 +431,16 @@
         method="post"
         action="{{ url_for('settings.toggle_demo_mode', compact=compact_value) }}"
       >
+        <input type="hidden" name="action" value="persist" />
+        <button type="submit" class="button" {% if not demo_status.active %}disabled{% endif %}>
+          Persist demo dataset
+        </button>
+      </form>
+
+      <form
+        method="post"
+        action="{{ url_for('settings.toggle_demo_mode', compact=compact_value) }}"
+      >
         <input type="hidden" name="action" value="refresh" />
         <button type="submit" class="button" {% if not demo_status.active %}disabled{% endif %}>
           Refresh demo data

--- a/tickettracker/views/settings.py
+++ b/tickettracker/views/settings.py
@@ -943,6 +943,16 @@ def toggle_demo_mode():
                         )
             else:
                 flash("Demo mode disabled.", "success")
+    elif action == "persist":
+        if not demo_manager.is_active:
+            flash("Enable demo mode before persisting the dataset.", "error")
+        else:
+            try:
+                dataset_path = demo_manager.persist_dataset()
+            except DemoModeError as exc:
+                flash(f"Unable to persist demo dataset: {exc}", "error")
+            else:
+                flash(f"Demo dataset saved to {dataset_path}.", "success")
     elif action == "refresh":
         try:
             demo_manager.refresh()


### PR DESCRIPTION
## Summary
- add a persist action button to the demo mode controls so the current dataset can be saved
- route the new persist action through toggle_demo_mode, invoking DemoModeManager.persist_dataset with helpful flash feedback
- implement DemoModeManager.persist_dataset to serialize the active demo database back to JSON and cover the flow with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa40ca6bb0832c88ee12ad30788601