### PR TITLE
Tighten clipboard summary spacing

### DIFF
--- a/templates/partials/ticket_clipboard_summary.html
+++ b/templates/partials/ticket_clipboard_summary.html
@@ -55,11 +55,11 @@
 ] %}
 {% set article_style_parts = article_properties + article_required_styles + (article_optional_styles if use_inline_styles else []) %}
 {% set article_style = article_style_parts | join('; ') %}
-{% set header_style = "display: flex; justify-content: space-between; gap: 20px; align-items: flex-start; margin-bottom: 24px; padding: 20px; border-radius: 24px; background: " ~ section_strong_background ~ "; border: 1px solid " ~ section_border ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
+{% set header_style = "display: flex; justify-content: space-between; gap: 18px; align-items: flex-start; margin-bottom: 18px; padding: 18px; border-radius: 24px; background: " ~ section_strong_background ~ "; border: 1px solid " ~ section_border ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
 {% set title_group_style = "display: flex; flex-direction: column; gap: 10px;" if use_inline_styles else "" %}
 {% set title_style = "margin: 0; font-size: 28px; line-height: 1.2; color: " ~ title_color ~ ";" if use_inline_styles else "" %}
 {% set timestamps_style = "display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: " ~ muted_color ~ "; text-align: right;" if use_inline_styles else "" %}
-{% set section_style = "margin-top: 24px; padding: 20px; border-radius: 24px; background: " ~ section_background ~ "; border: 1px solid " ~ section_border ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
+{% set section_style = "margin-top: 18px; padding: 18px; border-radius: 24px; background: " ~ section_background ~ "; border: 1px solid " ~ section_border ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
 {% set section_heading_style = "margin: 0 0 10px 0; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; color: " ~ muted_color ~ ";" if use_inline_styles else "" %}
 {% set paragraph_style = "margin: 0; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
 {% set table_style = "width: 100%; border-collapse: collapse;" if use_inline_styles else "" %}
@@ -72,7 +72,7 @@
 {% set sla_badge_style = badge_base_style + " background: rgba(56, 189, 248, 0.35); color: #f8fafc;" if badge_base_style else "" %}
 {% set status_note_style = "margin-left: 8px; font-size: 12px; color: " ~ muted_color ~ "; letter-spacing: 0.03em;" if use_inline_styles else "" %}
 {% set inline_hint_style = "margin-left: 8px; font-size: 12px; color: " ~ muted_color ~ "; letter-spacing: 0.03em;" if use_inline_styles else "" %}
-{% set tag_list_style = "list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 6px;" if use_inline_styles else "" %}
+{% set tag_list_style = "list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 4px;" if use_inline_styles else "" %}
 {% set tag_contexts = namespace(items=[]) %}
 {% if ticket.tags %}
   {% for tag in ticket.tags %}
@@ -92,12 +92,12 @@
   {% endfor %}
 {% endif %}
 {% set tag_entries = tag_contexts.items %}
-{% set timeline_style = "list-style: none; margin: 20px 0 0; padding: 0 0 0 20px; border-left: 2px solid " ~ timeline_border ~ "; display: grid; gap: 20px;" if use_inline_styles else "" %}
-{% set timeline_item_style = "position: relative; padding-left: 24px;" if use_inline_styles else "" %}
+{% set timeline_style = "list-style: none; margin: 18px 0 0; padding: 0 0 0 18px; border-left: 2px solid " ~ timeline_border ~ "; display: grid; gap: 18px;" if use_inline_styles else "" %}
+{% set timeline_item_style = "position: relative; padding-left: 18px;" if use_inline_styles else "" %}
 {% set timeline_marker_style = "position: absolute; left: -12px; top: 8px; width: 10px; height: 10px; border-radius: 50%; background: " ~ accent_color ~ "; box-shadow: 0 0 0 6px rgba(56, 189, 248, 0.18);" if use_inline_styles else "" %}
-{% set timeline_content_style = "background: " ~ timeline_surface ~ "; border: 1px solid " ~ timeline_border ~ "; border-radius: 16px; padding: 14px; color: " ~ text_color ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
-{% set timeline_meta_style = "display: flex; flex-wrap: wrap; gap: 6px 14px; font-size: 13px; color: " ~ muted_color ~ "; margin: 0 0 6px;" if use_inline_styles else "" %}
-{% set timeline_body_style = "margin: 0 0 6px 0; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
+{% set timeline_content_style = "background: " ~ timeline_surface ~ "; border: 1px solid " ~ timeline_border ~ "; border-radius: 16px; padding: 12px; color: " ~ text_color ~ "; box-shadow: " ~ section_shadow ~ ";" if use_inline_styles else "" %}
+{% set timeline_meta_style = "display: flex; flex-wrap: wrap; gap: 4px 12px; font-size: 13px; color: " ~ muted_color ~ "; margin: 0 0 4px;" if use_inline_styles else "" %}
+{% set timeline_body_style = "margin: 0 0 4px 0; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
 {% set timeline_body_last_style = "margin: 0; color: " ~ text_color ~ ";" if use_inline_styles else "" %}
 {% set article_property_rules = article_properties | join(';
     ') %}
@@ -137,10 +137,10 @@
   .ticket-clipboard-summary header {
     display: flex;
     justify-content: space-between;
-    gap: 1.25rem;
+    gap: 1.125rem;
     align-items: flex-start;
-    margin-bottom: 1.5rem;
-    padding: 1.25rem;
+    margin-bottom: 1.125rem;
+    padding: 1.125rem;
     border-radius: 1.5rem;
     background: var(--clipboard-surface-strong, rgba(255, 255, 255, 0.88));
     border: 1px solid var(--clipboard-border, rgba(148, 163, 184, 0.32));
@@ -170,8 +170,8 @@
   }
 
   .ticket-clipboard-summary .summary-section {
-    margin-top: 1.5rem;
-    padding: 1.25rem;
+    margin-top: 1.125rem;
+    padding: 1.125rem;
     border-radius: 1.5rem;
     background: var(--clipboard-surface, rgba(255, 255, 255, 0.86));
     border: 1px solid var(--clipboard-border, rgba(148, 163, 184, 0.32));
@@ -270,7 +270,7 @@
     list-style: none;
     display: flex;
     flex-wrap: wrap;
-    gap: 0.375rem;
+    gap: 0.25rem;
     margin: 0;
     padding: 0;
   }
@@ -289,16 +289,16 @@
 
   .ticket-clipboard-summary .summary-timeline {
     list-style: none;
-    margin: 1.25rem 0 0;
-    padding: 0 0 0 1.25rem;
+    margin: 1.125rem 0 0;
+    padding: 0 0 0 1.125rem;
     border-left: 2px solid var(--clipboard-timeline-border, rgba(148, 163, 184, 0.28));
     display: grid;
-    gap: 1.25rem;
+    gap: 1.125rem;
   }
 
   .ticket-clipboard-summary .summary-timeline li {
     position: relative;
-    padding-left: 1.5rem;
+    padding-left: 1.125rem;
   }
 
   .ticket-clipboard-summary .timeline-marker {
@@ -316,7 +316,7 @@
     background: var(--clipboard-timeline-surface, rgba(255, 255, 255, 0.92));
     border: 1px solid var(--clipboard-timeline-border, rgba(148, 163, 184, 0.28));
     border-radius: 1rem;
-    padding: 0.875rem;
+    padding: 0.75rem;
     color: var(--clipboard-text, #0f172a);
     box-shadow: var(--clipboard-shadow, 0 18px 40px rgba(15, 23, 42, 0.08));
   }
@@ -324,14 +324,14 @@
   .ticket-clipboard-summary .timeline-meta {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.375rem 0.875rem;
+    gap: 0.25rem 0.75rem;
     font-size: 0.8rem;
     color: var(--clipboard-muted, #475569);
-    margin-bottom: 0.375rem;
+    margin-bottom: 0.25rem;
   }
 
   .ticket-clipboard-summary .timeline-body {
-    margin: 0 0 0.375rem 0;
+    margin: 0 0 0.25rem 0;
     color: var(--clipboard-text, #0f172a);
   }
 


### PR DESCRIPTION
## Summary
- reduce clipboard summary header and section spacing for both inline and fallback styles
- tighten tag pill gaps and timeline padding so items sit closer together

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa4844e6b8832c9b103b8e3ce534e3