### PR TITLE
Add helper for safe newline rendering

### DIFF
--- a/templates/partials/ticket_clipboard_summary.html
+++ b/templates/partials/ticket_clipboard_summary.html
@@ -502,7 +502,7 @@
     {% if ticket.description %}
       <section class="summary-section" data-clipboard-section="description"{% if section_style %} style="{{ section_style }}"{% endif %}>
         <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>Description</h2>
-        <p{% if paragraph_style %} style="{{ paragraph_style }}"{% endif %}>{{ ticket.description|urlize|replace('\n', '<br />')|safe }}</p>
+        <p{% if paragraph_style %} style="{{ paragraph_style }}"{% endif %}>{{ ticket.description|urlize|linebreaks }}</p>
       </section>
     {% endif %}
   {% endcall %}
@@ -511,7 +511,7 @@
     {% if ticket.links %}
       <section class="summary-section" data-clipboard-section="links"{% if section_style %} style="{{ section_style }}"{% endif %}>
         <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>Links</h2>
-        <p{% if paragraph_style %} style="{{ paragraph_style }}"{% endif %}>{{ ticket.links|urlize|replace('\n', '<br />')|safe }}</p>
+        <p{% if paragraph_style %} style="{{ paragraph_style }}"{% endif %}>{{ ticket.links|urlize|linebreaks }}</p>
       </section>
     {% endif %}
   {% endcall %}
@@ -520,7 +520,7 @@
     {% if ticket.notes %}
       <section class="summary-section" data-clipboard-section="notes"{% if section_style %} style="{{ section_style }}"{% endif %}>
         <h2{% if section_heading_style %} style="{{ section_heading_style }}"{% endif %}>Notes</h2>
-        <p{% if paragraph_style %} style="{{ paragraph_style }}"{% endif %}>{{ ticket.notes|urlize|replace('\n', '<br />')|safe }}</p>
+        <p{% if paragraph_style %} style="{{ paragraph_style }}"{% endif %}>{{ ticket.notes|urlize|linebreaks }}</p>
       </section>
     {% endif %}
   {% endcall %}
@@ -565,7 +565,7 @@
                 {% else %}
                   {% set update_body_style = timeline_body_style %}
                 {% endif %}
-                <p class="timeline-body"{% if update_body_style %} style="{{ update_body_style }}"{% endif %}>{{ update.body|urlize|replace('\n', '<br />')|safe }}</p>
+                <p class="timeline-body"{% if update_body_style %} style="{{ update_body_style }}"{% endif %}>{{ update.body|urlize|linebreaks }}</p>
               </div>
             </li>
           {% endfor %}

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -145,7 +145,7 @@
   <section class="detail-grid">
     <div>
       <h3>Description</h3>
-      <p>{{ ticket.description|urlize|replace('\n', '<br />')|safe }}</p>
+      <p>{{ ticket.description|urlize|linebreaks }}</p>
     </div>
     <aside>
       <dl>
@@ -164,13 +164,13 @@
         {% if ticket.links %}
           <div>
             <dt>Links</dt>
-            <dd>{{ ticket.links|urlize }}</dd>
+            <dd>{{ ticket.links|urlize|linebreaks }}</dd>
           </div>
         {% endif %}
         {% if ticket.notes %}
           <div>
             <dt>Notes</dt>
-            <dd>{{ ticket.notes|urlize|replace('\n', '<br />')|safe }}</dd>
+            <dd>{{ ticket.notes|urlize|linebreaks }}</dd>
           </div>
         {% endif %}
       </dl>
@@ -252,7 +252,7 @@
                 <span class="status-change">{{ update.status_from or '—' }} → {{ update.status_to or '—' }}</span>
               {% endif %}
             </div>
-            <p>{{ update.body|urlize|replace('\n', '<br />')|safe }}</p>
+            <p>{{ update.body|urlize|linebreaks }}</p>
             {% if update.attachments %}
               <ul class="update-attachments">
                 {% for attachment in update.attachments %}


### PR DESCRIPTION
## Summary
- add a reusable `linebreaks` Jinja filter that safely converts newline sequences to `<br />`
- apply the filter to ticket descriptions, links, notes, and updates on the detail page
- update the clipboard summary to use the helper so copied HTML preserves multi-line formatting

## Testing
- pytest
- ruff check tickettracker/app.py

------
https://chatgpt.com/codex/tasks/task_e_68fa6ca4e350832cafc8e305c299eb98