### PR TITLE
Remove SLA prefix from clipboard due date labels

### DIFF
--- a/templates/partials/ticket_clipboard_summary.html
+++ b/templates/partials/ticket_clipboard_summary.html
@@ -449,7 +449,7 @@
           <tr>
             <th{% if th_style %} style="{{ th_style }}"{% endif %}>Due</th>
             <td{% if td_style %} style="{{ td_style }}"{% endif %}>
-              <span class="value-indicator due-value"{% if due_value_style %} style="{{ due_value_style }}"{% endif %}>{{ ticket.due_badge_label }}</span>
+              <span class="value-indicator due-value"{% if due_value_style %} style="{{ due_value_style }}"{% endif %}>{{ ticket.clipboard_due_badge_label or ticket.due_badge_label }}</span>
               {% if not ticket.due_date and ticket.age_reference_date %}
                 <span class="age-badge"{% if inline_hint_style %} style="{{ inline_hint_style }}"{% endif %}>Aging since {{ ticket.age_reference_date.strftime('%b %d, %Y') }}</span>
               {% endif %}

--- a/templates/partials/ticket_clipboard_summary.txt
+++ b/templates/partials/ticket_clipboard_summary.txt
@@ -11,8 +11,8 @@ Updated: {{ format_timestamp(ticket.updated_at) }}
 {% if 'meta' in sections %}
 Status: {{ ticket.status }}
 Priority: {{ ticket.priority }}
-Due: {{ ticket.due_badge_label }}
-{% if ticket.sla_countdown %}SLA: {{ ticket.sla_countdown }}
+Due: {{ ticket.clipboard_due_badge_label or ticket.due_badge_label }}
+{% if ticket.sla_countdown %}SLA: {{ ticket.sla_clipboard_countdown or ticket.sla_countdown }}
 {% endif %}
 
 {% endif %}


### PR DESCRIPTION
## Summary
- provide clipboard-friendly SLA countdown strings on tickets
- remove the "SLA : " prefix from SLA-driven due labels in the HTML and text clipboard summaries

## Testing
- pytest
- python -m compileall tickettracker

------
https://chatgpt.com/codex/tasks/task_e_68fa7031d56c832c9cfd1f5722d56cb4