### PR TITLE
Close filter panel when clicking outside

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -387,6 +387,18 @@
           /* ignore persistence errors */
         }
       });
+
+      document.addEventListener('click', function (event) {
+        if (!filterDetails.open) {
+          return;
+        }
+
+        if (filterDetails.contains(event.target)) {
+          return;
+        }
+
+        filterDetails.open = false;
+      });
     }
 
     const orderInput = document.querySelector('[data-sort-order]');


### PR DESCRIPTION
## Summary
- collapse the filter panel when a click occurs outside of the details element
- keep storing the preferred filter panel state in localStorage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fa70ddd1b4832caaf78786393185ac